### PR TITLE
:bug: Fix seeds account space allocation

### DIFF
--- a/src/state/delegated_account_seeds.rs
+++ b/src/state/delegated_account_seeds.rs
@@ -12,3 +12,30 @@ impl Discriminator for DelegateAccountSeeds {
         AccountDiscriminator::DelegationRecord
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialization() {
+        let seeds = DelegateAccountSeeds {
+            seeds: vec![
+                vec![],
+                vec![
+                    215, 233, 74, 188, 162, 203, 12, 212, 106, 87, 189, 226, 48, 38, 129, 7, 34,
+                    82, 254, 106, 161, 35, 74, 146, 30, 211, 164, 97, 139, 136, 136, 77,
+                ],
+            ],
+        };
+
+        // Serialize
+        let serialized = seeds.try_to_vec().expect("Serialization failed");
+
+        // Deserialize
+        let deserialized: DelegateAccountSeeds =
+            DelegateAccountSeeds::try_from_slice(&serialized).expect("Deserialization failed");
+
+        assert_eq!(deserialized.seeds, seeds.seeds);
+    }
+}


### PR DESCRIPTION
# :bug: Fix seeds account space allocation

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Bug | No | - |

## Problem

Incorrect allocated space for the seeds pda