### PR TITLE
chore: Add ephemeral balance pda utils

### DIFF
--- a/src/instruction_builder/close_ephemeral_balance.rs
+++ b/src/instruction_builder/close_ephemeral_balance.rs
@@ -1,15 +1,11 @@
 use solana_program::instruction::Instruction;
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 
-use crate::consts::EPHEMERAL_BALANCE;
 use crate::discriminant::DlpDiscriminant;
+use crate::pda::ephemeral_balance_from_payer;
 
 pub fn close_ephemeral_balance(payer: Pubkey, index: u8) -> Instruction {
-    let ephemeral_balance = Pubkey::find_program_address(
-        &[EPHEMERAL_BALANCE, &payer.to_bytes(), &[index]],
-        &crate::id(),
-    )
-    .0;
+    let ephemeral_balance = ephemeral_balance_from_payer(&payer, index);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/delegate_ephemeral_balance.rs
+++ b/src/instruction_builder/delegate_ephemeral_balance.rs
@@ -4,20 +4,19 @@ use solana_program::system_program;
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 
 use crate::args::DelegateEphemeralBalanceArgs;
-use crate::consts::{BUFFER, EPHEMERAL_BALANCE};
+use crate::consts::BUFFER;
 use crate::discriminant::DlpDiscriminant;
-use crate::pda::{delegation_metadata_pda_from_pubkey, delegation_record_pda_from_pubkey};
+use crate::pda::{
+    delegation_metadata_pda_from_pubkey, delegation_record_pda_from_pubkey,
+    ephemeral_balance_from_payer,
+};
 
 /// Delegate ephemeral balance
 pub fn delegate_ephemeral_balance(
     payer: Pubkey,
     args: DelegateEphemeralBalanceArgs,
 ) -> Instruction {
-    let delegate_account = Pubkey::find_program_address(
-        &[EPHEMERAL_BALANCE, &payer.to_bytes(), &[args.index]],
-        &crate::id(),
-    )
-    .0;
+    let delegate_account = ephemeral_balance_from_payer(&payer, args.index);
     let buffer =
         Pubkey::find_program_address(&[BUFFER, &delegate_account.to_bytes()], &crate::id());
     let delegation_record = delegation_record_pda_from_pubkey(&delegate_account);

--- a/src/instruction_builder/top_up_ephemeral_balance.rs
+++ b/src/instruction_builder/top_up_ephemeral_balance.rs
@@ -4,8 +4,8 @@ use solana_program::system_program;
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 
 use crate::args::TopUpEphemeralBalanceArgs;
-use crate::consts::EPHEMERAL_BALANCE;
 use crate::discriminant::DlpDiscriminant;
+use crate::pda::ephemeral_balance_from_payer;
 
 /// Builds a top-up ephemeral balance instruction.
 pub fn top_up_ephemeral_balance(
@@ -17,11 +17,7 @@ pub fn top_up_ephemeral_balance(
         amount: amount.unwrap_or(10000),
         index: index.unwrap_or(0),
     };
-    let ephemeral_balance = Pubkey::find_program_address(
-        &[EPHEMERAL_BALANCE, &payer.to_bytes(), &[args.index]],
-        &crate::id(),
-    )
-    .0;
+    let ephemeral_balance = ephemeral_balance_from_payer(&payer, args.index);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/pda.rs
+++ b/src/pda.rs
@@ -1,9 +1,8 @@
-use paste::paste;
-
 use crate::consts::{
-    BUFFER, COMMIT_RECORD, COMMIT_STATE, DELEGATION_METADATA, DELEGATION_RECORD, PROGRAM_CONFIG,
-    VALIDATOR_FEES_VAULT,
+    BUFFER, COMMIT_RECORD, COMMIT_STATE, DELEGATION_METADATA, DELEGATION_RECORD, EPHEMERAL_BALANCE,
+    PROGRAM_CONFIG, VALIDATOR_FEES_VAULT,
 };
+use paste::paste;
 
 // -----------------
 // Seeds
@@ -88,6 +87,23 @@ pda! { buffer }
 
 seeds! { program_config, PROGRAM_CONFIG }
 pda! { program_config }
+
+pub fn ephemeral_balance_from_payer(
+    payer: &solana_program::pubkey::Pubkey,
+    index: u8,
+) -> solana_program::pubkey::Pubkey {
+    ephemeral_balance_and_bump_from_payer(payer, index).0
+}
+
+pub fn ephemeral_balance_and_bump_from_payer(
+    payer: &solana_program::pubkey::Pubkey,
+    index: u8,
+) -> (solana_program::pubkey::Pubkey, u8) {
+    solana_program::pubkey::Pubkey::find_program_address(
+        &[EPHEMERAL_BALANCE, &payer.to_bytes(), &[index]],
+        &crate::id(),
+    )
+}
 
 #[cfg(test)]
 mod tests {

--- a/tests/test_top_up.rs
+++ b/tests/test_top_up.rs
@@ -5,7 +5,7 @@ use dlp::args::DelegateEphemeralBalanceArgs;
 use dlp::consts::{EPHEMERAL_BALANCE, FEES_VAULT};
 use dlp::pda::{
     delegation_metadata_pda_from_pubkey, delegation_record_pda_from_pubkey,
-    validator_fees_vault_pda_from_pubkey,
+    ephemeral_balance_from_payer, validator_fees_vault_pda_from_pubkey,
 };
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
@@ -147,10 +147,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
         },
     );
 
-    let (ephemeral_balance, _) = Pubkey::find_program_address(
-        &[EPHEMERAL_BALANCE, &payer_alt.pubkey().to_bytes(), &[0]],
-        &dlp::id(),
-    );
+    let ephemeral_balance = ephemeral_balance_from_payer(&payer_alt.pubkey(), 0);
 
     // Setup the delegated account PDA
     program_test.add_account(


### PR DESCRIPTION
## Add ephemeral balance pda utils

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |



<!-- greptile_comment -->

## Greptile Summary

This PR adds utility functions for ephemeral balance PDA derivation in the delegation program, centralizing the logic and improving code maintainability.

- Added `ephemeral_balance_from_payer` and `ephemeral_balance_and_bump_from_payer` functions in `src/pda.rs` for consistent PDA derivation
- Refactored `top_up_ephemeral_balance.rs`, `close_ephemeral_balance.rs`, and `delegate_ephemeral_balance.rs` to use new utility functions
- Updated tests to verify PDA derivation works correctly with new utilities
- Maintained existing functionality while improving code organization



<!-- /greptile_comment -->