### PR TITLE
feat: Allow to create ephemeral balance PDAs and delegate with payer

### DIFF
--- a/src/instruction_builder/delegate_ephemeral_balance.rs
+++ b/src/instruction_builder/delegate_ephemeral_balance.rs
@@ -14,9 +14,10 @@ use crate::pda::{
 /// Delegate ephemeral balance
 pub fn delegate_ephemeral_balance(
     payer: Pubkey,
+    pubkey: Pubkey,
     args: DelegateEphemeralBalanceArgs,
 ) -> Instruction {
-    let delegate_account = ephemeral_balance_from_payer(&payer, args.index);
+    let delegate_account = ephemeral_balance_from_payer(&pubkey, args.index);
     let buffer =
         Pubkey::find_program_address(&[BUFFER, &delegate_account.to_bytes()], &crate::id());
     let delegation_record = delegation_record_pda_from_pubkey(&delegate_account);
@@ -28,6 +29,7 @@ pub fn delegate_ephemeral_balance(
         program_id: crate::id(),
         accounts: vec![
             AccountMeta::new(payer, true),
+            AccountMeta::new(pubkey, true),
             AccountMeta::new(delegate_account, false),
             AccountMeta::new(buffer.0, false),
             AccountMeta::new(delegation_record, false),

--- a/src/instruction_builder/top_up_ephemeral_balance.rs
+++ b/src/instruction_builder/top_up_ephemeral_balance.rs
@@ -10,6 +10,7 @@ use crate::pda::ephemeral_balance_from_payer;
 /// Builds a top-up ephemeral balance instruction.
 pub fn top_up_ephemeral_balance(
     payer: Pubkey,
+    pubkey: Pubkey,
     amount: Option<u64>,
     index: Option<u8>,
 ) -> Instruction {
@@ -17,11 +18,12 @@ pub fn top_up_ephemeral_balance(
         amount: amount.unwrap_or(10000),
         index: index.unwrap_or(0),
     };
-    let ephemeral_balance = ephemeral_balance_from_payer(&payer, args.index);
+    let ephemeral_balance = ephemeral_balance_from_payer(&pubkey, args.index);
     Instruction {
         program_id: crate::id(),
         accounts: vec![
             AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(pubkey, false),
             AccountMeta::new(ephemeral_balance, false),
             AccountMeta::new_readonly(system_program::id(), false),
         ],

--- a/src/processor/delegate_ephemeral_balance.rs
+++ b/src/processor/delegate_ephemeral_balance.rs
@@ -15,18 +15,19 @@ pub fn process_delegate_ephemeral_balance(
     data: &[u8],
 ) -> ProgramResult {
     let mut args = DelegateEphemeralBalanceArgs::try_from_slice(data)?;
-    let [payer, delegate_account, buffer, delegation_record, delegation_metadata, system_program, delegation_program] =
+    let [payer, pubkey, delegate_account, buffer, delegation_record, delegation_metadata, system_program, delegation_program] =
         accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
     load_signer(payer)?;
+    load_signer(pubkey)?;
     load_program(system_program, system_program::id())?;
     load_program(delegation_program, crate::id())?;
 
     // Check seeds and derive bump
-    let seeds = &[EPHEMERAL_BALANCE, &payer.key.to_bytes(), &[args.index]];
+    let seeds = &[EPHEMERAL_BALANCE, &pubkey.key.to_bytes(), &[args.index]];
     let (address, bump) = Pubkey::find_program_address(seeds, &crate::id());
     if !address.eq(delegate_account.key) {
         return Err(ProgramError::InvalidSeeds);
@@ -41,7 +42,7 @@ pub fn process_delegate_ephemeral_balance(
         &[delegate_account.clone(), system_program.clone()],
         &[&[
             EPHEMERAL_BALANCE,
-            &payer.key.to_bytes(),
+            &pubkey.key.to_bytes(),
             &[args.index],
             &[bump],
         ]],
@@ -69,7 +70,7 @@ pub fn process_delegate_ephemeral_balance(
         ],
         &[&[
             EPHEMERAL_BALANCE,
-            &payer.key.to_bytes(),
+            &pubkey.key.to_bytes(),
             &[args.index],
             &[bump],
         ]],

--- a/src/processor/top_up_ephemeral_balance.rs
+++ b/src/processor/top_up_ephemeral_balance.rs
@@ -19,14 +19,14 @@ pub fn process_top_up_ephemeral_balance(
     let args = TopUpEphemeralBalanceArgs::try_from_slice(data)?;
 
     // Load Accounts
-    let [payer, ephemeral_balance_pda, system_program] = accounts else {
+    let [payer, pubkey, ephemeral_balance_pda, system_program] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
     load_signer(payer)?;
     load_program(system_program, system_program::id())?;
 
-    let seeds_ephemeral_balance_pda = [EPHEMERAL_BALANCE, &payer.key.to_bytes(), &[args.index]];
+    let seeds_ephemeral_balance_pda = [EPHEMERAL_BALANCE, &pubkey.key.to_bytes(), &[args.index]];
     let bump_ephemeral_balance = load_pda(
         ephemeral_balance_pda,
         &seeds_ephemeral_balance_pda,
@@ -39,10 +39,10 @@ pub fn process_top_up_ephemeral_balance(
         create_pda(
             ephemeral_balance_pda,
             &system_program::id(),
-            8,
+            0,
             &[
                 EPHEMERAL_BALANCE,
-                &payer.key.to_bytes(),
+                &pubkey.key.to_bytes(),
                 &[args.index],
                 &[bump_ephemeral_balance],
             ],


### PR DESCRIPTION
## feat: Allow to create ephemeral balance PDAs and delegate with a different payer

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

## Description

- Allow to have a payer different from the Ephemeral Balance PDAs reference pubkey
- This can allow to top up for a session keys or sponsor an initial balance for a user

<!-- greptile_comment -->

## Greptile Summary

This PR adds functionality to allow different payers for ephemeral balance PDAs, enabling use cases like session keys and sponsored balances by separating the payer from the reference pubkey.

- Modified `src/instruction_builder/top_up_ephemeral_balance.rs` to accept separate payer and pubkey parameters for PDA derivation
- Updated `src/processor/delegate_ephemeral_balance.rs` to require both payer and pubkey as signers for security
- Added test cases in `tests/test_top_up.rs` demonstrating sponsored balance functionality
- Changed PDA seed derivation to use pubkey instead of payer across all affected files
- Reduced space allocation from 8 to 0 bytes in ephemeral balance accounts since no data storage is needed



<!-- /greptile_comment -->