### PR TITLE
fix: allow commit at slot = prev slot

### DIFF
--- a/src/processor/commit_state.rs
+++ b/src/processor/commit_state.rs
@@ -54,11 +54,11 @@ pub fn process_commit_state(
     let mut delegation_metadata =
         DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_data)?;
 
-    // If the commit slot is greater than the last update slot, we can proceed.
-    // If the slot is equal or less, we simply do not commit.
+    // If the commit slot is greater or equal than the last update slot, we can proceed.
+    // If the slot is less, we simply do not commit.
     // Since commit instructions are typically bundled, we return without error
     // so that correct commits are executed.
-    if commit_record_slot <= delegation_metadata.last_update_external_slot {
+    if commit_record_slot < delegation_metadata.last_update_external_slot {
         msg!(
             "Slot {} is outdated, previous slot is {}. Skipping commit",
             commit_record_slot,


### PR DESCRIPTION
## fix: allow commit at slot = prev slot

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | - |

## Problem

An account can have commits for the same slot, where the state is equale, but one can allow for undelegation

## Solution

Allow to commit if slot is more or equal to the last committed slot

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the commit slot validation logic in the delegation program to allow multiple commits at the same slot number, specifically to support cases where equal state needs different undelegation settings.

- Modified commit validation in `src/processor/commit_state.rs` to accept commits where slot >= previous slot (instead of strictly >)
- Change enables multiple commits with identical state but different undelegation flags at same slot
- Test coverage in `test_commit_state.rs` verifies the new commit slot validation behavior
- Important for scenarios where undelegation settings need to be modified without waiting for next slot
- Consider adding documentation to clarify intended usage and potential race conditions



<!-- /greptile_comment -->