### PR TITLE
feat: set default identity on delegation

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,4 +14,5 @@ pub const EXTERNAL_UNDELEGATE_DISCRIMINATOR: [u8; 8] = [196, 28, 41, 206, 48, 37
 pub const DELEGATION_PROGRAM_ID: Pubkey = crate::id();
 
 /// Default validator identity (used when none is provided during delegation).
-pub const DEFAULT_VALIDATOR_IDENTITY: Pubkey = pubkey!("MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57");
+pub const DEFAULT_VALIDATOR_IDENTITY: Pubkey =
+    pubkey!("MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57");

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,3 +1,4 @@
+use solana_program::pubkey;
 use solana_program::pubkey::Pubkey;
 
 /// The delegation session fees (extracted in percentage from the delegation PDAs rent on closure).
@@ -11,3 +12,6 @@ pub const EXTERNAL_UNDELEGATE_DISCRIMINATOR: [u8; 8] = [196, 28, 41, 206, 48, 37
 
 /// The program ID of the delegation program.
 pub const DELEGATION_PROGRAM_ID: Pubkey = crate::id();
+
+/// Default validator identity (used when none is provided during delegation).
+pub const DEFAULT_VALIDATOR_IDENTITY: Pubkey = pubkey!("MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57");

--- a/src/processor/delegate.rs
+++ b/src/processor/delegate.rs
@@ -17,6 +17,7 @@ use crate::{
     delegate_buffer_seeds_from_delegated_account, delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account,
 };
+use crate::consts::DEFAULT_VALIDATOR_IDENTITY;
 
 /// Delegates an account
 ///
@@ -133,7 +134,7 @@ pub fn process_delegate(
     // Initialize the delegation record
     let delegation_record = DelegationRecord {
         owner: *owner_program.key,
-        authority: args.validator.unwrap_or(Pubkey::default()),
+        authority: args.validator.unwrap_or(DEFAULT_VALIDATOR_IDENTITY),
         commit_frequency_ms: args.commit_frequency_ms as u64,
         delegation_slot: solana_program::clock::Clock::get()?.slot,
         lamports: delegated_account.lamports(),

--- a/src/processor/delegate.rs
+++ b/src/processor/delegate.rs
@@ -7,6 +7,7 @@ use solana_program::{
 };
 
 use crate::args::DelegateArgs;
+use crate::consts::DEFAULT_VALIDATOR_IDENTITY;
 use crate::processor::utils::curve::is_on_curve;
 use crate::processor::utils::loaders::{
     load_owned_pda, load_pda, load_program, load_signer, load_uninitialized_pda,
@@ -17,7 +18,6 @@ use crate::{
     delegate_buffer_seeds_from_delegated_account, delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account,
 };
-use crate::consts::DEFAULT_VALIDATOR_IDENTITY;
 
 /// Delegates an account
 ///


### PR DESCRIPTION
## [Description](feat: set default identity on delegation)

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-04 15:42:38 UTC

This PR introduces a default validator identity mechanism for the delegation system. The change adds a new constant `DEFAULT_VALIDATOR_IDENTITY` in `src/consts.rs` that specifies a hardcoded validator pubkey (`MAS1Dt9qreoRMQ14YQuhg8UTZMMzDdKhmkZMECCzk57`) to serve as a fallback when no validator is explicitly provided during delegation operations.

The implementation modifies the delegation processor in `src/processor/delegate.rs` to use this default validator identity via `args.validator.unwrap_or(DEFAULT_VALIDATOR_IDENTITY)` instead of potentially allowing undefined behavior when `args.validator` is None. This ensures every delegation record has a valid authority field, which is essential for the delegation system's operation.

The change integrates well with the existing codebase architecture by following the established pattern of defining program constants in `consts.rs` alongside other important values like `RENT_FEES_PERCENTAGE` and `PROTOCOL_FEES_PERCENTAGE`. The use of the `pubkey!` macro creates a compile-time constant from the base58-encoded address, maintaining type safety and efficiency consistent with Solana program development best practices.

## Confidence score: 4/5

- This PR is safe to merge with low risk as it provides a sensible fallback mechanism
- Score reflects simple, well-structured changes that follow established patterns in the codebase
- Pay close attention to verifying the hardcoded validator pubkey is intentional and correct

<!-- /greptile_comment -->