### PR TITLE
feat: optimize commit-from-buffer instruction using Pinocchio for lower CU consumption

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,9 @@ pub fn fast_process_instruction(
         discriminator::DlpDiscriminator::CommitState => Some(
             processor::fast::process_commit_state(program_id, accounts, data),
         ),
+        discriminator::DlpDiscriminator::CommitStateFromBuffer => Some(
+            processor::fast::process_commit_state_from_buffer(program_id, accounts, data),
+        ),
         discriminator::DlpDiscriminator::Undelegate => Some(processor::fast::process_undelegate(
             program_id, accounts, data,
         )),

--- a/src/processor/fast/commit_state_from_buffer.rs
+++ b/src/processor/fast/commit_state_from_buffer.rs
@@ -1,0 +1,46 @@
+use crate::args::CommitStateFromBufferArgs;
+use crate::processor::fast::{process_commit_state_internal, CommitStateInternalArgs};
+
+use borsh::BorshDeserialize;
+use pinocchio::account_info::AccountInfo;
+use pinocchio::program_error::ProgramError;
+use pinocchio::pubkey::Pubkey;
+use pinocchio::ProgramResult;
+
+pub fn process_commit_state_from_buffer(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: &[u8],
+) -> ProgramResult {
+    let args =
+        CommitStateFromBufferArgs::try_from_slice(data).map_err(|_| ProgramError::BorshIoError)?;
+
+    let commit_record_lamports = args.lamports;
+    let commit_record_nonce = args.nonce;
+    let allow_undelegation = args.allow_undelegation;
+
+    let [validator, delegated_account, commit_state_account, commit_record_account, delegation_record_account, delegation_metadata_account, state_buffer_account, validator_fees_vault, program_config_account, system_program] =
+        accounts
+    else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+    let state = state_buffer_account.try_borrow_data()?;
+    let commit_state_bytes: &[u8] = &state;
+
+    let commit_args = CommitStateInternalArgs {
+        commit_state_bytes,
+        commit_record_lamports,
+        commit_record_nonce,
+        allow_undelegation,
+        validator,
+        delegated_account,
+        commit_state_account,
+        commit_record_account,
+        delegation_record_account,
+        delegation_metadata_account,
+        validator_fees_vault,
+        program_config_account,
+        system_program,
+    };
+    process_commit_state_internal(commit_args)
+}

--- a/src/processor/fast/mod.rs
+++ b/src/processor/fast/mod.rs
@@ -1,9 +1,11 @@
 mod commit_state;
+mod commit_state_from_buffer;
 mod delegate;
 mod undelegate;
 mod utils;
 
 pub use commit_state::*;
+pub use commit_state_from_buffer::*;
 pub use delegate::*;
 pub use undelegate::*;
 


### PR DESCRIPTION
It is the fourth PR in the current stack. See #94 (the first PR in the stack) for a detailed description.

I couldn't test it, as it's not currently being invoked by the integration tests.

This PR rewrites `process_commit_state_from_buffer()`, which is very similar to `process_commit_state()` &mdash; in fact both of them are implemented in terms of `process_commit_state_internal()`. So its performance improvement should be similar to the performance improvement seen for `process_commit_state()` (see #96).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for committing state directly from a buffer, available in both standard and optimized execution paths.
- Performance
  - Introduced a fast-path for buffered state commits to reduce latency and compute usage.
- Stability
  - Improved validation during buffered commits to ensure reliable processing and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->