### PR TITLE
fix: correct the conditions in requires.rs and return granular error

### DIFF
--- a/src/processor/fast/utils/requires.rs
+++ b/src/processor/fast/utils/requires.rs
@@ -74,12 +74,10 @@ pub fn require_pda(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    if !info.is_writable().eq(&is_writable) {
-        // TODO (snawaz): misleading msg
-        // also better use more granular error here ProgramError::InvalidPermission
+    if is_writable && !info.is_writable() {
         log!("Account needs to be writable. Label: {}", label);
         pubkey::log(info.key());
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(pda.1)
@@ -124,7 +122,7 @@ pub fn require_uninitialized_account(
     if is_writable && !info.is_writable() {
         log!("Account needs to be writable. label: {}, account: ", label);
         pubkey::log(info.key());
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(())
@@ -176,7 +174,7 @@ pub fn require_initialized_pda(
     if is_writable && !info.is_writable() {
         log!("Account needs to be writable. label: {}, account: ", label);
         pubkey::log(info.key());
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(pda.1)

--- a/src/processor/utils/loaders.rs
+++ b/src/processor/utils/loaders.rs
@@ -50,11 +50,9 @@ pub fn load_pda(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    if !info.is_writable.eq(&is_writable) {
-        // TODO (snawaz): misleading msg
-        // also better use more granular error here ProgramError::InvalidPermission
+    if is_writable && !info.is_writable {
         msg!("Account {} ({}) needs to be writable", label, info.key);
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(pda.1)
@@ -103,7 +101,7 @@ pub fn load_initialized_pda(
 
     if is_writable && !info.is_writable {
         msg!("Account {} is not writable", info.key);
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(pda.1)
@@ -143,7 +141,7 @@ pub fn load_uninitialized_account(
 
     if is_writable && !info.is_writable {
         msg!("Account {} ({}) needs to be writable", label, info.key);
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(())
@@ -178,7 +176,7 @@ pub fn load_account(
 
     if is_writable && !info.is_writable {
         msg!("Account {} ({}) needs to be writable", label, info.key);
-        return Err(ProgramError::InvalidAccountData);
+        return Err(ProgramError::Immutable);
     }
 
     Ok(())


### PR DESCRIPTION
As discussed in https://github.com/magicblock-labs/delegation-program/pull/94#discussion_r2422612552, this PR fixes the conditions in requires.rs (which was copied verbatim from loaders.rs &mdash; fixed that as well). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized errors when attempting to write to read-only accounts: now returns “Immutable” instead of a generic invalid data error, providing clearer feedback.
  * Consistent behavior across account loading and PDA-related operations.
* **Refactor**
  * Simplified writable checks for improved clarity, **also correcting the behavior for valid writable accounts**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->