### PR TITLE
fix: respect "no-entrypoint" feature

### DIFF
--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,13 +1,6 @@
-use crate::discriminator::DlpDiscriminator;
-use crate::processor::process_call_handler;
-use crate::{discriminator, processor};
+use crate::{fast_process_instruction, slow_process_instruction};
 
-use pinocchio_log::log;
-use solana_program::account_info::AccountInfo;
-use solana_program::entrypoint::ProgramResult;
-use solana_program::program_error::ProgramError;
-use solana_program::pubkey::Pubkey;
-use solana_program::{entrypoint, msg};
+use solana_program::entrypoint;
 
 entrypoint::custom_heap_default!();
 entrypoint::custom_panic_default!();
@@ -48,100 +41,4 @@ pub unsafe fn slow_entrypoint(input: *mut u8) -> u64 {
         Ok(()) => entrypoint::SUCCESS,
         Err(error) => error.into(),
     }
-}
-
-pub fn fast_process_instruction(
-    program_id: &pinocchio::pubkey::Pubkey,
-    accounts: &[pinocchio::account_info::AccountInfo],
-    data: &[u8],
-) -> Option<pinocchio::ProgramResult> {
-    if data.len() < 8 {
-        return Some(Err(
-            pinocchio::program_error::ProgramError::InvalidInstructionData,
-        ));
-    }
-
-    let (discriminator_bytes, data) = data.split_at(8);
-
-    let discriminator = match DlpDiscriminator::try_from(discriminator_bytes[0]) {
-        Ok(discriminator) => discriminator,
-        Err(_) => {
-            log!("Failed to read and parse discriminator");
-            return Some(Err(
-                pinocchio::program_error::ProgramError::InvalidInstructionData,
-            ));
-        }
-    };
-
-    match discriminator {
-        discriminator::DlpDiscriminator::Delegate => Some(processor::fast::process_delegate(
-            program_id, accounts, data,
-        )),
-        discriminator::DlpDiscriminator::CommitState => Some(
-            processor::fast::process_commit_state(program_id, accounts, data),
-        ),
-        discriminator::DlpDiscriminator::CommitStateFromBuffer => Some(
-            processor::fast::process_commit_state_from_buffer(program_id, accounts, data),
-        ),
-        discriminator::DlpDiscriminator::Finalize => Some(processor::fast::process_finalize(
-            program_id, accounts, data,
-        )),
-        discriminator::DlpDiscriminator::Undelegate => Some(processor::fast::process_undelegate(
-            program_id, accounts, data,
-        )),
-        _ => None,
-    }
-}
-
-pub fn slow_process_instruction(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    data: &[u8],
-) -> ProgramResult {
-    if data.len() < 8 {
-        return Err(ProgramError::InvalidInstructionData);
-    }
-
-    let (tag, data) = data.split_at(8);
-    let ix = discriminator::DlpDiscriminator::try_from(tag[0])
-        .or(Err(ProgramError::InvalidInstructionData))?;
-
-    msg!("Processing instruction: {:?}", ix);
-    match ix {
-        discriminator::DlpDiscriminator::InitValidatorFeesVault => {
-            processor::process_init_validator_fees_vault(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::InitProtocolFeesVault => {
-            processor::process_init_protocol_fees_vault(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::ValidatorClaimFees => {
-            processor::process_validator_claim_fees(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::WhitelistValidatorForProgram => {
-            processor::process_whitelist_validator_for_program(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::TopUpEphemeralBalance => {
-            processor::process_top_up_ephemeral_balance(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::DelegateEphemeralBalance => {
-            processor::process_delegate_ephemeral_balance(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::CloseEphemeralBalance => {
-            processor::process_close_ephemeral_balance(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::ProtocolClaimFees => {
-            processor::process_protocol_claim_fees(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::CloseValidatorFeesVault => {
-            processor::process_close_validator_fees_vault(program_id, accounts, data)?
-        }
-        discriminator::DlpDiscriminator::CallHandler => {
-            process_call_handler(program_id, accounts, data)?
-        }
-        _ => {
-            log!("PANIC: Instruction must be processed by fast_process_instruction");
-            return Err(ProgramError::InvalidInstructionData);
-        }
-    }
-    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #![allow(unexpected_cfgs)] // silence clippy for target_os solana and other solana program custom features
 
-use solana_program::declare_id;
+use crate::discriminator::DlpDiscriminator;
+use pinocchio_log::log;
+use solana_program::account_info::AccountInfo;
+use solana_program::entrypoint::ProgramResult;
+use solana_program::program_error::ProgramError;
+use solana_program::pubkey::Pubkey;
+use solana_program::{declare_id, msg};
 
 pub mod args;
 pub mod consts;
@@ -30,4 +36,99 @@ solana_security_txt::security_txt! {
     policy: "https://github.com/magicblock-labs/delegation-program/blob/master/LICENSE.md",
     preferred_languages: "en",
     source_code: "https://github.com/magicblock-labs/delegation-program"
+}
+
+pub fn fast_process_instruction(
+    program_id: &pinocchio::pubkey::Pubkey,
+    accounts: &[pinocchio::account_info::AccountInfo],
+    data: &[u8],
+) -> Option<pinocchio::ProgramResult> {
+    if data.len() < 8 {
+        return Some(Err(
+            pinocchio::program_error::ProgramError::InvalidInstructionData,
+        ));
+    }
+
+    let (discriminator_bytes, data) = data.split_at(8);
+
+    let discriminator = match DlpDiscriminator::try_from(discriminator_bytes[0]) {
+        Ok(discriminator) => discriminator,
+        Err(_) => {
+            log!("Failed to read and parse discriminator");
+            return Some(Err(
+                pinocchio::program_error::ProgramError::InvalidInstructionData,
+            ));
+        }
+    };
+
+    match discriminator {
+        DlpDiscriminator::Delegate => Some(processor::fast::process_delegate(
+            program_id, accounts, data,
+        )),
+        DlpDiscriminator::CommitState => Some(processor::fast::process_commit_state(
+            program_id, accounts, data,
+        )),
+        DlpDiscriminator::CommitStateFromBuffer => Some(
+            processor::fast::process_commit_state_from_buffer(program_id, accounts, data),
+        ),
+        DlpDiscriminator::Finalize => Some(processor::fast::process_finalize(
+            program_id, accounts, data,
+        )),
+        DlpDiscriminator::Undelegate => Some(processor::fast::process_undelegate(
+            program_id, accounts, data,
+        )),
+        _ => None,
+    }
+}
+
+pub fn slow_process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: &[u8],
+) -> ProgramResult {
+    if data.len() < 8 {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let (tag, data) = data.split_at(8);
+    let ix = DlpDiscriminator::try_from(tag[0]).or(Err(ProgramError::InvalidInstructionData))?;
+
+    msg!("Processing instruction: {:?}", ix);
+    match ix {
+        DlpDiscriminator::InitValidatorFeesVault => {
+            processor::process_init_validator_fees_vault(program_id, accounts, data)?
+        }
+        DlpDiscriminator::InitProtocolFeesVault => {
+            processor::process_init_protocol_fees_vault(program_id, accounts, data)?
+        }
+        DlpDiscriminator::ValidatorClaimFees => {
+            processor::process_validator_claim_fees(program_id, accounts, data)?
+        }
+        DlpDiscriminator::WhitelistValidatorForProgram => {
+            processor::process_whitelist_validator_for_program(program_id, accounts, data)?
+        }
+        DlpDiscriminator::TopUpEphemeralBalance => {
+            processor::process_top_up_ephemeral_balance(program_id, accounts, data)?
+        }
+        DlpDiscriminator::DelegateEphemeralBalance => {
+            processor::process_delegate_ephemeral_balance(program_id, accounts, data)?
+        }
+        DlpDiscriminator::CloseEphemeralBalance => {
+            processor::process_close_ephemeral_balance(program_id, accounts, data)?
+        }
+        DlpDiscriminator::ProtocolClaimFees => {
+            processor::process_protocol_claim_fees(program_id, accounts, data)?
+        }
+        DlpDiscriminator::CloseValidatorFeesVault => {
+            processor::process_close_validator_fees_vault(program_id, accounts, data)?
+        }
+        DlpDiscriminator::CallHandler => {
+            processor::process_call_handler(program_id, accounts, data)?
+        }
+        _ => {
+            log!("PANIC: Instruction must be processed by fast_process_instruction");
+            return Err(ProgramError::InvalidInstructionData);
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | [Link](<Issue link here>) |

## Problem

_What problem are you trying to solve?_
no-entrypoint feature isn't respected anymore, which leads to sdk users having
`error: the `#[global_allocator]` in this crate conflicts with global allocator in: dlp
`
## Solution

_How did you solve the problem?_
Move entrypoint related logic into respective file and use no-entrypoint feature

## Before & After Screenshots

_Insert screenshots of example code output_

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]


## Other changes (e.g. bug fixes, small refactors)


## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implements a dual-path runtime that attempts a fast execution path and automatically falls back to a comprehensive slow path when needed.

* **Performance Improvements**
  * Faster handling for supported instructions, reducing transaction latency.

* **Reliability**
  * Robust fallback ensures broader instruction coverage and consistent status codes.

* **Error Handling**
  * Improved diagnostics for malformed or unknown instructions.

* **Refactor**
  * Entrypoint logic consolidated and gated by a build feature; instruction discriminator handling simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->