### PR TITLE
feat: Optimize `CommitDiff` using efficient `merge_diff_copy` that avoids heap allocation 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,10 +35,12 @@ pub enum DlpError {
     Overflow = 13,
     #[error("Too many seeds")]
     TooManySeeds = 14,
-    #[error("Invalid diff passed to DiffSet::try_new")]
+    #[error("Invalid length of diff passed to DiffSet::try_new")]
     InvalidDiff = 15,
     #[error("Diff is not properly aligned")]
     InvalidDiffAlignment = 16,
+    #[error("MergeDiff precondition did not meet")]
+    MergeDiffError = 17,
 }
 
 impl From<DlpError> for ProgramError {

--- a/src/processor/fast/commit_diff.rs
+++ b/src/processor/fast/commit_diff.rs
@@ -6,7 +6,9 @@ use pinocchio_log::log;
 
 use crate::args::{CommitDiffArgsWithoutDiff, SIZE_COMMIT_DIFF_ARGS_WITHOUT_DIFF};
 use crate::processor::fast::{process_commit_state_internal, CommitStateInternalArgs};
-use crate::{apply_diff_copy, DiffSet};
+use crate::DiffSet;
+
+use super::NewState;
 
 /// Commit diff to a delegated PDA
 ///
@@ -70,14 +72,8 @@ pub fn process_commit_diff(
     let commit_record_nonce = args.nonce;
     let allow_undelegation = args.allow_undelegation;
 
-    // TODO (snawaz): the following approach to apply diff works, but it's not efficient.
-    // It is also problematic for larger account as it allocates memory on the heap.
-    // It will be fixed in a separate PR.
-    let original = unsafe { delegated_account.borrow_data_unchecked() };
-    let changed = apply_diff_copy(original, &diffset)?;
-
     let commit_args = CommitStateInternalArgs {
-        commit_state_bytes: &changed,
+        commit_state_bytes: NewState::Diff(diffset),
         commit_record_lamports,
         commit_record_nonce,
         allow_undelegation,

--- a/src/processor/fast/commit_state_from_buffer.rs
+++ b/src/processor/fast/commit_state_from_buffer.rs
@@ -7,6 +7,8 @@ use pinocchio::program_error::ProgramError;
 use pinocchio::pubkey::Pubkey;
 use pinocchio::ProgramResult;
 
+use super::NewState;
+
 pub fn process_commit_state_from_buffer(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -26,10 +28,9 @@ pub fn process_commit_state_from_buffer(
     let allow_undelegation = args.allow_undelegation;
 
     let state = state_buffer_account.try_borrow_data()?;
-    let commit_state_bytes: &[u8] = &state;
 
     let commit_args = CommitStateInternalArgs {
-        commit_state_bytes,
+        commit_state_bytes: NewState::FullBytes(&state),
         commit_record_lamports,
         commit_record_nonce,
         allow_undelegation,


### PR DESCRIPTION
It is the third PR in the current stack.

The previous PR #110 used an inefficient approach to diff application that allocates memory on the heap, which can be problematic for larger accounts.

## Solution

This PR adds a new `merge_diff_copy()` function that applies diffs directly to a destination buffer without requiring additional memory allocation. This function takes a `destination buffer`, `original data`, and a `DiffSet`.. and then merges the original with the diff to produce the updated version in the destination buffer. The whole approach avoids unnecessary memory allocation.

Apart from that, it also adds `enum NewState` to represent either **full bytes** or a **diff**, and `process_commit_state_internal()` is modified to handle both full data and diffs using `NewState`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal diff application and state management for enhanced performance and clarity.

* **Bug Fixes**
  * Enhanced error handling with new validation for diff operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->