### PR TITLE
fix: capping solana program version due to transit dependency issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ logging = []
 
 [dependencies]
 borsh = { version = "1.5.3", features = [ "derive" ] }
-solana-program = { version = ">=1.16" }
+solana-program = { version = ">=1.16, <3.0.0" }
 bytemuck = { version = ">=1", features = [ "derive" ] }
 num_enum = "^0.7.2"
 thiserror = { version = ">=1" }


### PR DESCRIPTION
## Problem

Programs using ephemeral-rollups-sdk may unintentionally build with latest solana-program which triggers type errors for `Pubkey` by `solana-program 3.0.0` and above.


## Solution

Capping solana-program version will fix dependency issues and type errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solana Program dependency version constraints for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->