### PR TITLE
fix: unresolved import in sdk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod processor;
 pub use diff::*;
 
 // re-export
+#[cfg(not(feature = "sdk"))]
 pub use rkyv;
 
 #[cfg(feature = "log-cost")]


### PR DESCRIPTION
## Problem

SDK triggers error "unresolved import" when building.


## Solution

Set feature flag "sdk" for optional import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added serialization library to the public API when the SDK feature is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->