### PR TITLE
chore: add rustfmt.toml with some sensible format settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	@cargo build-sbf
+
+test:
+	RUST_LOG=off cargo test-sbf --features unit_test_config
+
+fmt:
+	cargo +nightly fmt

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+unstable_features = true
+max_width = 80
+edition = "2021"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/src/account_size_class.rs
+++ b/src/account_size_class.rs
@@ -13,7 +13,8 @@ const MB: u32 = 1024 * KB;
 //  That is because each *_size_budget() function includes this constant, so callers must subtract (N-1) instances
 //  when combining multiple instructions.
 //
-pub const DLP_PROGRAM_DATA_SIZE_CLASS: AccountSizeClass = AccountSizeClass::Dynamic(350 * KB);
+pub const DLP_PROGRAM_DATA_SIZE_CLASS: AccountSizeClass =
+    AccountSizeClass::Dynamic(350 * KB);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AccountSizeClass {

--- a/src/args/commit_state.rs
+++ b/src/args/commit_state.rs
@@ -1,7 +1,7 @@
-use bytemuck::{Pod, Zeroable};
 use std::mem::size_of;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use bytemuck::{Pod, Zeroable};
 
 use crate::args::{ArgsWithBuffer, Boolean};
 
@@ -35,7 +35,8 @@ pub struct CommitFinalizeArgs {
     pub reserved_padding: [u8; 3],
 }
 
-pub type CommitFinalizeArgsWithBuffer<'a> = ArgsWithBuffer<'a, CommitFinalizeArgs>;
+pub type CommitFinalizeArgsWithBuffer<'a> =
+    ArgsWithBuffer<'a, CommitFinalizeArgs>;
 
 #[derive(Default, Debug, BorshSerialize, BorshDeserialize)]
 pub struct CommitStateArgs {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,6 +1,5 @@
 use pinocchio::Address;
-use solana_program::pubkey;
-use solana_program::pubkey::Pubkey;
+use solana_program::{pubkey, pubkey::Pubkey};
 
 /// The delegation session fees (extracted in percentage from the delegation PDAs rent on closure).
 pub const RENT_FEES_PERCENTAGE: u8 = 10;
@@ -15,7 +14,8 @@ pub const COMMIT_FEE_LAMPORTS: u64 = 100_000;
 pub const SESSION_FEE_LAMPORTS: u64 = 300_000;
 
 /// The discriminator for the external undelegate instruction.
-pub const EXTERNAL_UNDELEGATE_DISCRIMINATOR: [u8; 8] = [196, 28, 41, 206, 48, 37, 51, 167];
+pub const EXTERNAL_UNDELEGATE_DISCRIMINATOR: [u8; 8] =
+    [196, 28, 41, 206, 48, 37, 51, 167];
 
 /// The program ID of the delegation program.
 pub const DELEGATION_PROGRAM_ID: Pubkey = crate::id();
@@ -32,11 +32,13 @@ pub const DEFAULT_VALIDATOR_IDENTITY: Pubkey =
 /// The broadcast identity marks an account as undelegatable.
 /// Validators treat it as always delegatable, which is safe since such accounts
 /// cannot be committed or delegated
-pub const BROADCAST_IDENTITY: Pubkey = pubkey!("Broadcast1111111111111111111111111111111111");
+pub const BROADCAST_IDENTITY: Pubkey =
+    pubkey!("Broadcast1111111111111111111111111111111111");
 
-pub const BPF_LOADER_UPGRADEABLE_ID: Address = Address::new_from_array(
-    const_crypto::bs58::decode_pubkey("BPFLoaderUpgradeab1e11111111111111111111111"),
-);
+pub const BPF_LOADER_UPGRADEABLE_ID: Address =
+    Address::new_from_array(const_crypto::bs58::decode_pubkey(
+        "BPFLoaderUpgradeab1e11111111111111111111111",
+    ));
 
 pub const DELEGATION_PROGRAM_DATA_ID: Address = Address::new_from_array(
     const_crypto::ed25519::derive_program_address(

--- a/src/diff/algorithm.rs
+++ b/src/diff/algorithm.rs
@@ -3,14 +3,11 @@ use std::cmp::{min, Ordering};
 use pinocchio::error::ProgramError;
 use rkyv::util::AlignedVec;
 
-use crate::error::DlpError;
-
 use super::{
-    DiffSet, OffsetInData, SizeChanged, SIZE_OF_CHANGED_LEN, SIZE_OF_NUM_OFFSET_PAIRS,
-    SIZE_OF_SINGLE_OFFSET_PAIR,
+    DiffSet, OffsetInData, SizeChanged, SIZE_OF_CHANGED_LEN,
+    SIZE_OF_NUM_OFFSET_PAIRS, SIZE_OF_SINGLE_OFFSET_PAIR,
 };
-
-use crate::{require_eq, require_le};
+use crate::{error::DlpError, require_eq, require_le};
 
 ///
 /// Compute diff between original and changed.
@@ -191,7 +188,10 @@ pub fn compute_diff(original: &[u8], changed: &[u8]) -> AlignedVec {
 ///  - None               means NO change
 ///  - Some(size_changed) means the data size has changed and size_changed indicates
 ///                       whether it has expanded or shrunk.
-pub fn detect_size_change(original: &[u8], diffset: &DiffSet<'_>) -> Option<SizeChanged> {
+pub fn detect_size_change(
+    original: &[u8],
+    diffset: &DiffSet<'_>,
+) -> Option<SizeChanged> {
     match diffset.changed_len().cmp(&original.len()) {
         Ordering::Less => Some(SizeChanged::Shrunk(diffset.changed_len())),
         Ordering::Greater => Some(SizeChanged::Expanded(diffset.changed_len())),
@@ -203,7 +203,10 @@ pub fn detect_size_change(original: &[u8], diffset: &DiffSet<'_>) -> Option<Size
 ///
 /// Precondition:
 ///   - original.len() must be equal to the length encoded in the diff.
-pub fn apply_diff_in_place(original: &mut [u8], diffset: &DiffSet<'_>) -> Result<(), ProgramError> {
+pub fn apply_diff_in_place(
+    original: &mut [u8],
+    diffset: &DiffSet<'_>,
+) -> Result<(), ProgramError> {
     if let Some(_layout) = detect_size_change(original, diffset) {
         return Err(ProgramError::InvalidInstructionData);
     }
@@ -212,7 +215,10 @@ pub fn apply_diff_in_place(original: &mut [u8], diffset: &DiffSet<'_>) -> Result
 
 /// This function creates a copy of original, possibly extending or shrinking it,
 /// and then applies the diff to it, before returning it.
-pub fn apply_diff_copy(original: &[u8], diffset: &DiffSet<'_>) -> Result<Vec<u8>, ProgramError> {
+pub fn apply_diff_copy(
+    original: &[u8],
+    diffset: &DiffSet<'_>,
+) -> Result<Vec<u8>, ProgramError> {
     Ok(match detect_size_change(original, diffset) {
         Some(SizeChanged::Expanded(new_size)) => {
             let mut applied = Vec::with_capacity(new_size);
@@ -273,7 +279,8 @@ pub fn merge_diff_copy<'a>(
         if write_index < start {
             require_le!(start, original.len(), DlpError::InvalidDiff);
             // copy the unchanged bytes
-            destination[write_index..start].copy_from_slice(&original[write_index..start]);
+            destination[write_index..start]
+                .copy_from_slice(&original[write_index..start]);
         }
 
         destination[start..end].copy_from_slice(diff_segment);
@@ -319,12 +326,14 @@ pub fn merge_diff_copy<'a>(
             if destination.len() <= original.len() {
                 // case: all n bytes come from original
                 let dest_len = destination.len();
-                destination[write_index..].copy_from_slice(&original[write_index..dest_len]);
+                destination[write_index..]
+                    .copy_from_slice(&original[write_index..dest_len]);
                 dest_len
             } else if write_index < original.len() {
                 // case: some bytes come from original and the rest are "assumed" to be
                 // zero-initialized (by the caller).
-                destination[write_index..original.len()].copy_from_slice(&original[write_index..]);
+                destination[write_index..original.len()]
+                    .copy_from_slice(&original[write_index..]);
                 original.len()
             } else {
                 // case: all N bytes are "assumed" to be zero-initialized (by the caller).
@@ -344,7 +353,10 @@ pub fn merge_diff_copy<'a>(
 }
 
 // private function that does the actual work.
-fn apply_diff_impl(original: &mut [u8], diffset: &DiffSet<'_>) -> Result<(), ProgramError> {
+fn apply_diff_impl(
+    original: &mut [u8],
+    diffset: &DiffSet<'_>,
+) -> Result<(), ProgramError> {
     for item in diffset.iter() {
         let (diff_segment, offset_range) = item?;
         original[offset_range].copy_from_slice(diff_segment);
@@ -361,7 +373,10 @@ mod tests {
         Rng, RngCore, SeedableRng,
     };
 
-    use crate::{apply_diff_copy, apply_diff_in_place, compute_diff, merge_diff_copy, DiffSet};
+    use crate::{
+        apply_diff_copy, apply_diff_in_place, compute_diff, merge_diff_copy,
+        DiffSet,
+    };
 
     #[test]
     fn test_no_change() {
@@ -395,8 +410,9 @@ mod tests {
             // 2 (u32)
             expected_diff.extend_from_slice(&2u32.to_le_bytes());
         } else {
-            expected_diff
-                .extend_from_slice(&(2u32 + additional_changes.len() as u32).to_le_bytes());
+            expected_diff.extend_from_slice(
+                &(2u32 + additional_changes.len() as u32).to_le_bytes(),
+            );
         }
 
         // -- offsets
@@ -450,13 +466,15 @@ mod tests {
         assert_eq!(actual_diff.len(), 4 + 4 + 8 + 8 + (4 + 8));
         assert_eq!(actual_diff.as_slice(), expected_diff.as_slice());
 
-        let expected_changed = apply_diff_copy(&original, &actual_diffset).unwrap();
+        let expected_changed =
+            apply_diff_copy(&original, &actual_diffset).unwrap();
 
         assert_eq!(changed.as_slice(), expected_changed.as_slice());
 
         let expected_changed = {
             let mut destination = vec![255; original.len()];
-            merge_diff_copy(&mut destination, &original, &actual_diffset).unwrap();
+            merge_diff_copy(&mut destination, &original, &actual_diffset)
+                .unwrap();
             destination
         };
 
@@ -492,7 +510,8 @@ mod tests {
 
         let expected_changed = {
             let mut destination = vec![255; CHANGED_LEN];
-            merge_diff_copy(&mut destination, &original, &actual_diffset).unwrap();
+            merge_diff_copy(&mut destination, &original, &actual_diffset)
+                .unwrap();
             destination
         };
 
@@ -525,14 +544,17 @@ mod tests {
         //
         // TODO (snawaz): we could optimize compute_diff to not include the zero bytes which are
         // part of the expansion.
-        let expected_diff = get_example_expected_diff(CHANGED_LEN, vec![(100, &[0; 20])]);
+        let expected_diff =
+            get_example_expected_diff(CHANGED_LEN, vec![(100, &[0; 20])]);
 
         assert_eq!(actual_diff.len(), 4 + 4 + (8 + 8) + (4 + 8) + (4 + 4 + 20));
         assert_eq!(actual_diff.as_slice(), expected_diff.as_slice());
 
         let expected_changed = {
             let mut destination = vec![255; CHANGED_LEN];
-            let unwritten = merge_diff_copy(&mut destination, &original, &actual_diffset).unwrap();
+            let unwritten =
+                merge_diff_copy(&mut destination, &original, &actual_diffset)
+                    .unwrap();
 
             // TODO (snawaz): unwritten == &mut [], is because currently the expanded bytes are part of the diff.
             // Once compute_diff is optimized further, written must be &mut [0; 20].
@@ -587,7 +609,8 @@ mod tests {
                     }
                 }
                 // println!("{diff_offset}, {diff_end} => {diff_len}");
-                slices.push((diff_offset, copy[diff_offset..diff_end].to_vec()));
+                slices
+                    .push((diff_offset, copy[diff_offset..diff_end].to_vec()));
 
                 offset_range = (diff_end + 8)..(diff_end + 8 + slab);
             }
@@ -606,7 +629,9 @@ mod tests {
             let mut offset_in_diff = 0u32;
             for (offset_in_account, slice) in slices.iter() {
                 diff.extend_from_slice(&offset_in_diff.to_le_bytes());
-                diff.extend_from_slice(&(*offset_in_account as u32).to_le_bytes());
+                diff.extend_from_slice(
+                    &(*offset_in_account as u32).to_le_bytes(),
+                );
                 offset_in_diff += slice.len() as u32;
             }
 
@@ -634,7 +659,8 @@ mod tests {
 
         let expected_changed = {
             let mut destination = vec![255; original.len()];
-            merge_diff_copy(&mut destination, &original, &actual_diffset).unwrap();
+            merge_diff_copy(&mut destination, &original, &actual_diffset)
+                .unwrap();
             destination
         };
 

--- a/src/diff/types.rs
+++ b/src/diff/types.rs
@@ -92,7 +92,8 @@ impl<'a> DiffSet<'a> {
                 //  - raw_pairs aligned to 4-byte
                 //  - raw_pairs is big enough to hold both changed_len and segments_count
                 this.offset_pairs = unsafe {
-                    let raw_pairs = buf.add(SIZE_OF_CHANGED_LEN + SIZE_OF_NUM_OFFSET_PAIRS)
+                    let raw_pairs = buf
+                        .add(SIZE_OF_CHANGED_LEN + SIZE_OF_NUM_OFFSET_PAIRS)
                         as *const OffsetPair;
                     slice::from_raw_parts(raw_pairs, segments_count)
                 };
@@ -103,7 +104,9 @@ impl<'a> DiffSet<'a> {
         Ok(this)
     }
 
-    pub fn try_new_from_borsh_vec(vec_buffer: &'a [u8]) -> Result<Self, ProgramError> {
+    pub fn try_new_from_borsh_vec(
+        vec_buffer: &'a [u8],
+    ) -> Result<Self, ProgramError> {
         if vec_buffer.len() < 4 {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -164,9 +167,10 @@ impl<'a> DiffSet<'a> {
             return Err(DlpError::InvalidDiff.into());
         }
 
-        let segment = &self.concat_diff[segment_begin as usize..segment_end as usize];
-        let range =
-            offset_in_data as usize..(offset_in_data + segment_end - segment_begin) as usize;
+        let segment =
+            &self.concat_diff[segment_begin as usize..segment_end as usize];
+        let range = offset_in_data as usize
+            ..(offset_in_data + segment_end - segment_begin) as usize;
 
         if range.end > self.changed_len() {
             return Err(DlpError::InvalidDiff.into());
@@ -178,7 +182,8 @@ impl<'a> DiffSet<'a> {
     /// Iterates diff segments
     pub fn iter(
         &self,
-    ) -> impl Iterator<Item = Result<(&'a [u8], OffsetInData), ProgramError>> + '_ {
+    ) -> impl Iterator<Item = Result<(&'a [u8], OffsetInData), ProgramError>> + '_
+    {
         (0..self.segments_count).map(|index| {
             self.diff_segment_at(index)
                 .map(|val| val.expect("impossible: index can never be greater than segments_count"))

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,6 +1,8 @@
-use crate::{error::DlpError, fast_process_instruction, slow_process_instruction};
-
 use solana_program::entrypoint;
+
+use crate::{
+    error::DlpError, fast_process_instruction, slow_process_instruction,
+};
 
 entrypoint::custom_heap_default!();
 entrypoint::custom_panic_default!();
@@ -15,8 +17,9 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
         core::mem::MaybeUninit::<pinocchio::AccountView>::uninit();
     let mut accounts = [UNINIT; { pinocchio::MAX_TX_ACCOUNTS }];
 
-    let (program_id, count, data) =
-        pinocchio::entrypoint::deserialize::<{ pinocchio::MAX_TX_ACCOUNTS }>(input, &mut accounts);
+    let (program_id, count, data) = pinocchio::entrypoint::deserialize::<
+        { pinocchio::MAX_TX_ACCOUNTS },
+    >(input, &mut accounts);
 
     match fast_process_instruction(
         program_id,
@@ -25,7 +28,10 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     ) {
         Some(Ok(())) => pinocchio::SUCCESS,
         Some(Err(error)) => {
-            pinocchio_log::log!("fast_process_instruction: {}", error.to_str::<DlpError>());
+            pinocchio_log::log!(
+                "fast_process_instruction: {}",
+                error.to_str::<DlpError>()
+            );
             error.into()
         }
 
@@ -40,7 +46,8 @@ pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
 /// function name is slow_entrypoint() as opposed to entrypoint() because this is a fallback
 /// entrypoint (a slow one).
 pub unsafe fn slow_entrypoint(input: *mut u8) -> u64 {
-    let (program_id, accounts, instruction_data) = unsafe { entrypoint::deserialize(input) };
+    let (program_id, accounts, instruction_data) =
+        unsafe { entrypoint::deserialize(input) };
     match slow_process_instruction(program_id, &accounts, instruction_data) {
         Ok(()) => entrypoint::SUCCESS,
         Err(error) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,19 @@ use strum::IntoStaticStr;
 use thiserror::Error;
 
 pub const INVALID_ESCROW_PDA: &str = "invalid escrow pda in CallHandler";
-pub const INVALID_ESCROW_OWNER: &str = "escrow can not be delegated in CallHandler";
+pub const INVALID_ESCROW_OWNER: &str =
+    "escrow can not be delegated in CallHandler";
 
 #[derive(
-    Debug, Error, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive, IntoStaticStr,
+    Debug,
+    Error,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    IntoPrimitive,
+    TryFromPrimitive,
+    IntoStaticStr,
 )]
 #[repr(u32)]
 pub enum DlpError {

--- a/src/instruction_builder/call_handler.rs
+++ b/src/instruction_builder/call_handler.rs
@@ -1,10 +1,18 @@
-use crate::args::CallHandlerArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{ephemeral_balance_pda_from_payer, validator_fees_vault_pda_from_validator};
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+use crate::{
+    args::CallHandlerArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        ephemeral_balance_pda_from_payer,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a call handler instruction.
 /// See [crate::processor::call_handler] for docs.
@@ -16,10 +24,12 @@ pub fn call_handler(
     other_accounts: Vec<AccountMeta>,
     args: CallHandlerArgs,
 ) -> Instruction {
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
 
     // handler accounts
-    let escrow_account = ephemeral_balance_pda_from_payer(&escrow_authority, args.escrow_index);
+    let escrow_account =
+        ephemeral_balance_pda_from_payer(&escrow_authority, args.escrow_index);
     let mut accounts = vec![
         AccountMeta::new(validator, true),
         AccountMeta::new(validator_fees_vault_pda, false),
@@ -46,7 +56,10 @@ pub fn call_handler(
 ///
 /// This value can be used with ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit
 ///
-pub fn call_handler_size_budget(destination_program: AccountSizeClass, other_accounts: u32) -> u32 {
+pub fn call_handler_size_budget(
+    destination_program: AccountSizeClass,
+    other_accounts: u32,
+) -> u32 {
     total_size_budget(&[
         DLP_PROGRAM_DATA_SIZE_CLASS,
         AccountSizeClass::Tiny, // validator

--- a/src/instruction_builder/call_handler_v2.rs
+++ b/src/instruction_builder/call_handler_v2.rs
@@ -1,10 +1,18 @@
-use crate::args::CallHandlerArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{ephemeral_balance_pda_from_payer, validator_fees_vault_pda_from_validator};
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+use crate::{
+    args::CallHandlerArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        ephemeral_balance_pda_from_payer,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a call handler v2 instruction.
 /// See [crate::processor::call_handler_v2] for docs.
@@ -16,10 +24,12 @@ pub fn call_handler_v2(
     other_accounts: Vec<AccountMeta>,
     args: CallHandlerArgs,
 ) -> Instruction {
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
 
     // handler accounts
-    let escrow_account = ephemeral_balance_pda_from_payer(&escrow_authority, args.escrow_index);
+    let escrow_account =
+        ephemeral_balance_pda_from_payer(&escrow_authority, args.escrow_index);
     let mut accounts = vec![
         AccountMeta::new(validator, true),
         AccountMeta::new(validator_fees_vault_pda, false),

--- a/src/instruction_builder/close_ephemeral_balance.rs
+++ b/src/instruction_builder/close_ephemeral_balance.rs
@@ -1,8 +1,12 @@
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey, system_program};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::ephemeral_balance_pda_from_payer;
+use crate::{
+    discriminator::DlpDiscriminator, pda::ephemeral_balance_pda_from_payer,
+};
 
 /// Creates instruction to close an ephemeral balance account
 /// See [crate::processor::process_close_ephemeral_balance] for docs.

--- a/src/instruction_builder/close_validator_fees_vault.rs
+++ b/src/instruction_builder/close_validator_fees_vault.rs
@@ -1,8 +1,12 @@
-use crate::consts::DELEGATION_PROGRAM_DATA_ID;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::validator_fees_vault_pda_from_validator;
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+use crate::{
+    consts::DELEGATION_PROGRAM_DATA_ID, discriminator::DlpDiscriminator,
+    pda::validator_fees_vault_pda_from_validator,
+};
 
 /// Close a validator fees vault PDA.
 /// See [crate::processor::process_close_validator_fees_vault] for docs.
@@ -11,7 +15,8 @@ pub fn close_validator_fees_vault(
     admin: Pubkey,
     validator_identity: Pubkey,
 ) -> Instruction {
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator_identity);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator_identity);
     let delegation_program_data = DELEGATION_PROGRAM_DATA_ID.to_bytes().into();
     Instruction {
         program_id: crate::id(),

--- a/src/instruction_builder/commit_diff.rs
+++ b/src/instruction_builder/commit_diff.rs
@@ -1,16 +1,23 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::args::CommitDiffArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    program_config_from_program_id, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    args::CommitDiffArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a commit state instruction.
 /// See [crate::processor::fast::process_commit_diff] for docs.
@@ -21,13 +28,18 @@ pub fn commit_diff(
     commit_args: CommitDiffArgs,
 ) -> Instruction {
     let commit_args = to_vec(&commit_args).unwrap();
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
-    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+    let program_config_pda =
+        program_config_from_program_id(&delegated_account_owner);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/commit_diff_from_buffer.rs
+++ b/src/instruction_builder/commit_diff_from_buffer.rs
@@ -1,16 +1,23 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::args::CommitStateFromBufferArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    program_config_from_program_id, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    args::CommitStateFromBufferArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a commit state from buffer instruction.
 /// See [crate::processor::process_commit_diff_from_buffer] for docs.
@@ -22,13 +29,18 @@ pub fn commit_diff_from_buffer(
     commit_args: CommitStateFromBufferArgs,
 ) -> Instruction {
     let commit_args = to_vec(&commit_args).unwrap();
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
-    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+    let program_config_pda =
+        program_config_from_program_id(&delegated_account_owner);
     Instruction {
         program_id: crate::id(),
         accounts: vec![
@@ -43,7 +55,8 @@ pub fn commit_diff_from_buffer(
             AccountMeta::new_readonly(program_config_pda, false),
             AccountMeta::new_readonly(system_program::id(), false),
         ],
-        data: [DlpDiscriminator::CommitDiffFromBuffer.to_vec(), commit_args].concat(),
+        data: [DlpDiscriminator::CommitDiffFromBuffer.to_vec(), commit_args]
+            .concat(),
     }
 }
 
@@ -52,7 +65,9 @@ pub fn commit_diff_from_buffer(
 ///
 /// This value can be used with ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit
 ///
-pub fn commit_diff_from_buffer_size_budget(delegated_account: AccountSizeClass) -> u32 {
+pub fn commit_diff_from_buffer_size_budget(
+    delegated_account: AccountSizeClass,
+) -> u32 {
     total_size_budget(&[
         DLP_PROGRAM_DATA_SIZE_CLASS,
         AccountSizeClass::Tiny, // validator

--- a/src/instruction_builder/commit_finalize.rs
+++ b/src/instruction_builder/commit_finalize.rs
@@ -1,14 +1,17 @@
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::args::{CommitBumps, CommitFinalizeArgs};
-use crate::discriminator::DlpDiscriminator;
-use crate::pod_view::PodView;
 use crate::{
+    args::{CommitBumps, CommitFinalizeArgs},
     delegation_metadata_seeds_from_delegated_account,
-    delegation_record_seeds_from_delegated_account, total_size_budget,
-    validator_fees_vault_seeds_from_validator, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+    delegation_record_seeds_from_delegated_account,
+    discriminator::DlpDiscriminator,
+    pod_view::PodView,
+    total_size_budget, validator_fees_vault_seeds_from_validator,
+    AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
 };
 
 pub struct CommitPDAs {

--- a/src/instruction_builder/commit_finalize_from_buffer.rs
+++ b/src/instruction_builder/commit_finalize_from_buffer.rs
@@ -1,14 +1,17 @@
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::args::{CommitBumps, CommitFinalizeArgs};
-use crate::discriminator::DlpDiscriminator;
-use crate::pod_view::PodView;
 use crate::{
+    args::{CommitBumps, CommitFinalizeArgs},
     delegation_metadata_seeds_from_delegated_account,
-    delegation_record_seeds_from_delegated_account, total_size_budget,
-    validator_fees_vault_seeds_from_validator, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+    delegation_record_seeds_from_delegated_account,
+    discriminator::DlpDiscriminator,
+    pod_view::PodView,
+    total_size_budget, validator_fees_vault_seeds_from_validator,
+    AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
 };
 
 /// Builds a commit state from buffer instruction.
@@ -72,7 +75,9 @@ pub fn commit_finalize_from_buffer(
 ///
 /// This value can be used with ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit
 ///
-pub fn commit_finalize_from_buffer_size_budget(delegated_account: AccountSizeClass) -> u32 {
+pub fn commit_finalize_from_buffer_size_budget(
+    delegated_account: AccountSizeClass,
+) -> u32 {
     total_size_budget(&[
         DLP_PROGRAM_DATA_SIZE_CLASS,
         AccountSizeClass::Tiny, // validator

--- a/src/instruction_builder/commit_state.rs
+++ b/src/instruction_builder/commit_state.rs
@@ -1,16 +1,23 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::args::CommitStateArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    program_config_from_program_id, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    args::CommitStateArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a commit state instruction.
 /// See [crate::processor::process_commit_state] for docs.
@@ -21,13 +28,18 @@ pub fn commit_state(
     commit_args: CommitStateArgs,
 ) -> Instruction {
     let commit_args = to_vec(&commit_args).unwrap();
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
-    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+    let program_config_pda =
+        program_config_from_program_id(&delegated_account_owner);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/commit_state_from_buffer.rs
+++ b/src/instruction_builder/commit_state_from_buffer.rs
@@ -1,16 +1,23 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::args::CommitStateFromBufferArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    program_config_from_program_id, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    args::CommitStateFromBufferArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a commit state from buffer instruction.
 /// See [crate::processor::process_commit_state_from_buffer] for docs.
@@ -22,13 +29,18 @@ pub fn commit_state_from_buffer(
     commit_args: CommitStateFromBufferArgs,
 ) -> Instruction {
     let commit_args = to_vec(&commit_args).unwrap();
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
-    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+    let program_config_pda =
+        program_config_from_program_id(&delegated_account_owner);
     Instruction {
         program_id: crate::id(),
         accounts: vec![
@@ -56,7 +68,9 @@ pub fn commit_state_from_buffer(
 ///
 /// This value can be used with ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit
 ///
-pub fn commit_state_from_buffer_size_budget(delegated_account: AccountSizeClass) -> u32 {
+pub fn commit_state_from_buffer_size_budget(
+    delegated_account: AccountSizeClass,
+) -> u32 {
     total_size_budget(&[
         DLP_PROGRAM_DATA_SIZE_CLASS,
         AccountSizeClass::Tiny, // validator

--- a/src/instruction_builder/delegate.rs
+++ b/src/instruction_builder/delegate.rs
@@ -1,15 +1,20 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::args::DelegateArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    delegate_buffer_pda_from_delegated_account_and_owner_program,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    args::DelegateArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a delegate instruction
 /// See [crate::processor::process_delegate] for docs.
@@ -54,8 +59,12 @@ fn build_delegate_instruction(
 ) -> Instruction {
     let owner = owner.unwrap_or(system_program::id());
     let delegate_buffer_pda =
-        delegate_buffer_pda_from_delegated_account_and_owner_program(&delegated_account, &owner);
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+        delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &delegated_account,
+            &owner,
+        );
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
     let mut data = discriminator.to_vec();

--- a/src/instruction_builder/delegate_ephemeral_balance.rs
+++ b/src/instruction_builder/delegate_ephemeral_balance.rs
@@ -1,14 +1,19 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::args::DelegateEphemeralBalanceArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    delegate_buffer_pda_from_delegated_account_and_owner_program,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    ephemeral_balance_pda_from_payer,
+use crate::{
+    args::DelegateEphemeralBalanceArgs,
+    discriminator::DlpDiscriminator,
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        ephemeral_balance_pda_from_payer,
+    },
 };
 
 /// Delegate ephemeral balance
@@ -18,12 +23,15 @@ pub fn delegate_ephemeral_balance(
     pubkey: Pubkey,
     args: DelegateEphemeralBalanceArgs,
 ) -> Instruction {
-    let delegated_account = ephemeral_balance_pda_from_payer(&pubkey, args.index);
-    let delegate_buffer_pda = delegate_buffer_pda_from_delegated_account_and_owner_program(
-        &delegated_account,
-        &system_program::id(),
-    );
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+    let delegated_account =
+        ephemeral_balance_pda_from_payer(&pubkey, args.index);
+    let delegate_buffer_pda =
+        delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &delegated_account,
+            &system_program::id(),
+        );
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
     let mut data = DlpDiscriminator::DelegateEphemeralBalance.to_vec();

--- a/src/instruction_builder/finalize.rs
+++ b/src/instruction_builder/finalize.rs
@@ -1,24 +1,34 @@
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds a finalize state instruction.
 /// See [crate::processor::process_finalize] for docs.
 pub fn finalize(validator: Pubkey, delegated_account: Pubkey) -> Instruction {
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/init_protocol_fees_vault.rs
+++ b/src/instruction_builder/init_protocol_fees_vault.rs
@@ -1,9 +1,10 @@
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::fees_vault_pda;
+use crate::{discriminator::DlpDiscriminator, pda::fees_vault_pda};
 
 /// Initialize the fees vault PDA.
 /// See [crate::processor::process_init_protocol_fees_vault] for docs.

--- a/src/instruction_builder/init_validator_fees_vault.rs
+++ b/src/instruction_builder/init_validator_fees_vault.rs
@@ -1,9 +1,13 @@
-use crate::consts::DELEGATION_PROGRAM_DATA_ID;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::validator_fees_vault_pda_from_validator;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
+
+use crate::{
+    consts::DELEGATION_PROGRAM_DATA_ID, discriminator::DlpDiscriminator,
+    pda::validator_fees_vault_pda_from_validator,
+};
 
 /// Initialize a validator fees vault PDA.
 /// See [crate::processor::process_init_validator_fees_vault] for docs.
@@ -12,7 +16,8 @@ pub fn init_validator_fees_vault(
     admin: Pubkey,
     validator_identity: Pubkey,
 ) -> Instruction {
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator_identity);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator_identity);
     let delegation_program_data = DELEGATION_PROGRAM_DATA_ID.to_bytes().into();
     Instruction {
         program_id: crate::id(),

--- a/src/instruction_builder/protocol_claim_fees.rs
+++ b/src/instruction_builder/protocol_claim_fees.rs
@@ -1,8 +1,12 @@
-use crate::consts::DELEGATION_PROGRAM_DATA_ID;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::fees_vault_pda;
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+
+use crate::{
+    consts::DELEGATION_PROGRAM_DATA_ID, discriminator::DlpDiscriminator,
+    pda::fees_vault_pda,
+};
 
 /// Claim the accrued fees from the protocol fees vault.
 /// See [crate::processor::process_protocol_claim_fees] for docs.

--- a/src/instruction_builder/top_up_ephemeral_balance.rs
+++ b/src/instruction_builder/top_up_ephemeral_balance.rs
@@ -1,11 +1,14 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::args::TopUpEphemeralBalanceArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::ephemeral_balance_pda_from_payer;
+use crate::{
+    args::TopUpEphemeralBalanceArgs, discriminator::DlpDiscriminator,
+    pda::ephemeral_balance_pda_from_payer,
+};
 
 /// Builds a top-up ephemeral balance instruction.
 /// See [crate::processor::process_top_up_ephemeral_balance] for docs.
@@ -19,7 +22,8 @@ pub fn top_up_ephemeral_balance(
         amount: amount.unwrap_or(10000),
         index: index.unwrap_or(0),
     };
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&pubkey, args.index);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&pubkey, args.index);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/undelegate.rs
+++ b/src/instruction_builder/undelegate.rs
@@ -1,15 +1,21 @@
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, undelegate_buffer_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use crate::{total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS};
+
+use crate::{
+    discriminator::DlpDiscriminator,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account, fees_vault_pda,
+        undelegate_buffer_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    total_size_budget, AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
+};
 
 /// Builds an undelegate instruction.
 /// See [crate::processor::process_undelegate] for docs.
@@ -20,14 +26,19 @@ pub fn undelegate(
     owner_program: Pubkey,
     rent_reimbursement: Pubkey,
 ) -> Instruction {
-    let undelegate_buffer_pda = undelegate_buffer_pda_from_delegated_account(&delegated_account);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&delegated_account);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&delegated_account);
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+    let undelegate_buffer_pda =
+        undelegate_buffer_pda_from_delegated_account(&delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&delegated_account);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
     let fees_vault_pda = fees_vault_pda();
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/undelegate_confined_account.rs
+++ b/src/instruction_builder/undelegate_confined_account.rs
@@ -1,11 +1,18 @@
-use crate::consts::DELEGATION_PROGRAM_DATA_ID;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    undelegate_buffer_pda_from_delegated_account,
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
 };
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey, system_program};
+
+use crate::{
+    consts::DELEGATION_PROGRAM_DATA_ID,
+    discriminator::DlpDiscriminator,
+    pda::{
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        undelegate_buffer_pda_from_delegated_account,
+    },
+};
 
 /// Builds an admin-only undelegate instruction for confined accounts.
 /// See [crate::processor::process_undelegate_confined_account] for docs.
@@ -14,8 +21,10 @@ pub fn undelegate_confined_account(
     delegated_account: Pubkey,
     owner_program: Pubkey,
 ) -> Instruction {
-    let undelegate_buffer_pda = undelegate_buffer_pda_from_delegated_account(&delegated_account);
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+    let undelegate_buffer_pda =
+        undelegate_buffer_pda_from_delegated_account(&delegated_account);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
     let delegation_program_data = DELEGATION_PROGRAM_DATA_ID.to_bytes().into();

--- a/src/instruction_builder/validator_claim_fees.rs
+++ b/src/instruction_builder/validator_claim_fees.rs
@@ -1,17 +1,25 @@
 use borsh::to_vec;
-use solana_program::instruction::Instruction;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
 
-use crate::args::ValidatorClaimFeesArgs;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::{fees_vault_pda, validator_fees_vault_pda_from_validator};
+use crate::{
+    args::ValidatorClaimFeesArgs,
+    discriminator::DlpDiscriminator,
+    pda::{fees_vault_pda, validator_fees_vault_pda_from_validator},
+};
 
 /// Claim the accrued fees from the fees vault.
 /// See [crate::processor::process_validator_claim_fees] for docs.
-pub fn validator_claim_fees(validator: Pubkey, amount: Option<u64>) -> Instruction {
+pub fn validator_claim_fees(
+    validator: Pubkey,
+    amount: Option<u64>,
+) -> Instruction {
     let args = ValidatorClaimFeesArgs { amount };
     let fees_vault_pda = fees_vault_pda();
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator);
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator);
     Instruction {
         program_id: crate::id(),
         accounts: vec![

--- a/src/instruction_builder/whitelist_validator_for_program.rs
+++ b/src/instruction_builder/whitelist_validator_for_program.rs
@@ -1,13 +1,15 @@
 use borsh::to_vec;
-use solana_program::bpf_loader_upgradeable;
-use solana_program::instruction::Instruction;
-use solana_program::system_program;
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
+use solana_program::{
+    bpf_loader_upgradeable,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    system_program,
+};
 
-use crate::args::WhitelistValidatorForProgramArgs;
-use crate::consts::DELEGATION_PROGRAM_DATA_ID;
-use crate::discriminator::DlpDiscriminator;
-use crate::pda::program_config_from_program_id;
+use crate::{
+    args::WhitelistValidatorForProgramArgs, consts::DELEGATION_PROGRAM_DATA_ID,
+    discriminator::DlpDiscriminator, pda::program_config_from_program_id,
+};
 
 /// Whitelist validator for program
 ///
@@ -19,8 +21,11 @@ pub fn whitelist_validator_for_program(
     insert: bool,
 ) -> Instruction {
     let args = WhitelistValidatorForProgramArgs { insert };
-    let program_data =
-        Pubkey::find_program_address(&[program.as_ref()], &bpf_loader_upgradeable::id()).0;
+    let program_data = Pubkey::find_program_address(
+        &[program.as_ref()],
+        &bpf_loader_upgradeable::id(),
+    )
+    .0;
     let delegation_program_data = DELEGATION_PROGRAM_DATA_ID.to_bytes().into();
     let program_config_pda = program_config_from_program_id(&program);
     Instruction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,26 +2,26 @@
 
 // Exactly one of `sdk` or `program` must be enabled
 #[cfg(all(feature = "sdk", feature = "program"))]
-compile_error!("Features `sdk` and `program` are mutually exclusive. Enable exactly one.");
+compile_error!(
+    "Features `sdk` and `program` are mutually exclusive. Enable exactly one."
+);
 
 #[cfg(all(not(feature = "sdk"), not(feature = "program")))]
 compile_error!(
     "Enable either `program` (default) or `sdk`. Building with neither is not supported."
 );
 
+use solana_program::declare_id;
+#[cfg(feature = "logging")]
+use solana_program::msg;
 #[cfg(not(feature = "sdk"))]
 use {
     crate::discriminator::DlpDiscriminator,
     solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
-        pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult,
+        program_error::ProgramError, pubkey::Pubkey,
     },
 };
-
-use solana_program::declare_id;
-
-#[cfg(feature = "logging")]
-use solana_program::msg;
 
 pub mod args;
 pub mod consts;
@@ -44,7 +44,6 @@ mod processor;
 
 #[cfg(not(feature = "sdk"))]
 pub use diff::*;
-
 // re-export
 #[cfg(not(feature = "sdk"))]
 pub use rkyv;
@@ -59,7 +58,9 @@ declare_id!("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");
 
 #[cfg(not(feature = "sdk"))]
 pub mod fast {
-    pinocchio::address::declare_id!("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");
+    pinocchio::address::declare_id!(
+        "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh"
+    );
 }
 
 #[cfg(feature = "solana-security-txt")]
@@ -79,16 +80,21 @@ pub fn fast_process_instruction(
     data: &[u8],
 ) -> Option<pinocchio::ProgramResult> {
     if data.len() < 8 {
-        return Some(Err(pinocchio::error::ProgramError::InvalidInstructionData));
+        return Some(Err(
+            pinocchio::error::ProgramError::InvalidInstructionData,
+        ));
     }
 
     let (discriminator_bytes, data) = data.split_at(8);
 
-    let discriminator = match DlpDiscriminator::try_from(discriminator_bytes[0]) {
+    let discriminator = match DlpDiscriminator::try_from(discriminator_bytes[0])
+    {
         Ok(discriminator) => discriminator,
         Err(_) => {
             pinocchio_log::log!("Failed to read and parse discriminator");
-            return Some(Err(pinocchio::error::ProgramError::InvalidInstructionData));
+            return Some(Err(
+                pinocchio::error::ProgramError::InvalidInstructionData,
+            ));
         }
     };
 
@@ -99,36 +105,48 @@ pub fn fast_process_instruction(
         DlpDiscriminator::Delegate => Some(processor::fast::process_delegate(
             program_id, accounts, data,
         )),
-        DlpDiscriminator::DelegateWithAnyValidator => Some(
-            processor::fast::process_delegate_with_any_validator(program_id, accounts, data),
+        DlpDiscriminator::DelegateWithAnyValidator => {
+            Some(processor::fast::process_delegate_with_any_validator(
+                program_id, accounts, data,
+            ))
+        }
+        DlpDiscriminator::CommitState => Some(
+            processor::fast::process_commit_state(program_id, accounts, data),
         ),
-        DlpDiscriminator::CommitState => Some(processor::fast::process_commit_state(
-            program_id, accounts, data,
-        )),
-        DlpDiscriminator::CommitStateFromBuffer => Some(
-            processor::fast::process_commit_state_from_buffer(program_id, accounts, data),
+        DlpDiscriminator::CommitStateFromBuffer => {
+            Some(processor::fast::process_commit_state_from_buffer(
+                program_id, accounts, data,
+            ))
+        }
+        DlpDiscriminator::CommitDiff => Some(
+            processor::fast::process_commit_diff(program_id, accounts, data),
         ),
-        DlpDiscriminator::CommitDiff => Some(processor::fast::process_commit_diff(
-            program_id, accounts, data,
-        )),
-        DlpDiscriminator::CommitDiffFromBuffer => Some(
-            processor::fast::process_commit_diff_from_buffer(program_id, accounts, data),
-        ),
-        DlpDiscriminator::CommitFinalize => Some(processor::fast::process_commit_finalize(
-            program_id, accounts, data,
-        )),
-        DlpDiscriminator::CommitFinalizeFromBuffer => Some(
-            processor::fast::process_commit_finalize_from_buffer(program_id, accounts, data),
-        ),
+        DlpDiscriminator::CommitDiffFromBuffer => {
+            Some(processor::fast::process_commit_diff_from_buffer(
+                program_id, accounts, data,
+            ))
+        }
+        DlpDiscriminator::CommitFinalize => {
+            Some(processor::fast::process_commit_finalize(
+                program_id, accounts, data,
+            ))
+        }
+        DlpDiscriminator::CommitFinalizeFromBuffer => {
+            Some(processor::fast::process_commit_finalize_from_buffer(
+                program_id, accounts, data,
+            ))
+        }
         DlpDiscriminator::Finalize => Some(processor::fast::process_finalize(
             program_id, accounts, data,
         )),
-        DlpDiscriminator::Undelegate => Some(processor::fast::process_undelegate(
-            program_id, accounts, data,
-        )),
-        DlpDiscriminator::UndelegateConfinedAccount => Some(
-            processor::fast::process_undelegate_confined_account(program_id, accounts, data),
+        DlpDiscriminator::Undelegate => Some(
+            processor::fast::process_undelegate(program_id, accounts, data),
         ),
+        DlpDiscriminator::UndelegateConfinedAccount => {
+            Some(processor::fast::process_undelegate_confined_account(
+                program_id, accounts, data,
+            ))
+        }
         _ => None,
     }
 }
@@ -144,35 +162,50 @@ pub fn slow_process_instruction(
     }
 
     let (tag, data) = data.split_at(8);
-    let ix = DlpDiscriminator::try_from(tag[0]).or(Err(ProgramError::InvalidInstructionData))?;
+    let ix = DlpDiscriminator::try_from(tag[0])
+        .or(Err(ProgramError::InvalidInstructionData))?;
 
     match ix {
         DlpDiscriminator::InitValidatorFeesVault => {
-            processor::process_init_validator_fees_vault(program_id, accounts, data)?
+            processor::process_init_validator_fees_vault(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::InitProtocolFeesVault => {
-            processor::process_init_protocol_fees_vault(program_id, accounts, data)?
+            processor::process_init_protocol_fees_vault(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::ValidatorClaimFees => {
             processor::process_validator_claim_fees(program_id, accounts, data)?
         }
         DlpDiscriminator::WhitelistValidatorForProgram => {
-            processor::process_whitelist_validator_for_program(program_id, accounts, data)?
+            processor::process_whitelist_validator_for_program(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::TopUpEphemeralBalance => {
-            processor::process_top_up_ephemeral_balance(program_id, accounts, data)?
+            processor::process_top_up_ephemeral_balance(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::DelegateEphemeralBalance => {
-            processor::process_delegate_ephemeral_balance(program_id, accounts, data)?
+            processor::process_delegate_ephemeral_balance(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::CloseEphemeralBalance => {
-            processor::process_close_ephemeral_balance(program_id, accounts, data)?
+            processor::process_close_ephemeral_balance(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::ProtocolClaimFees => {
             processor::process_protocol_claim_fees(program_id, accounts, data)?
         }
         DlpDiscriminator::CloseValidatorFeesVault => {
-            processor::process_close_validator_fees_vault(program_id, accounts, data)?
+            processor::process_close_validator_fees_vault(
+                program_id, accounts, data,
+            )?
         }
         DlpDiscriminator::CallHandler => {
             processor::process_call_handler(program_id, accounts, data)?

--- a/src/pda.rs
+++ b/src/pda.rs
@@ -95,7 +95,9 @@ macro_rules! ephemeral_balance_seeds_from_payer {
     };
 }
 
-pub fn delegation_record_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
+pub fn delegation_record_pda_from_delegated_account(
+    delegated_account: &Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         delegation_record_seeds_from_delegated_account!(delegated_account),
         &crate::id(),
@@ -103,7 +105,9 @@ pub fn delegation_record_pda_from_delegated_account(delegated_account: &Pubkey) 
     .0
 }
 
-pub fn delegation_metadata_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
+pub fn delegation_metadata_pda_from_delegated_account(
+    delegated_account: &Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         delegation_metadata_seeds_from_delegated_account!(delegated_account),
         &crate::id(),
@@ -111,7 +115,9 @@ pub fn delegation_metadata_pda_from_delegated_account(delegated_account: &Pubkey
     .0
 }
 
-pub fn commit_state_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
+pub fn commit_state_pda_from_delegated_account(
+    delegated_account: &Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         commit_state_seeds_from_delegated_account!(delegated_account),
         &crate::id(),
@@ -119,7 +125,9 @@ pub fn commit_state_pda_from_delegated_account(delegated_account: &Pubkey) -> Pu
     .0
 }
 
-pub fn commit_record_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
+pub fn commit_record_pda_from_delegated_account(
+    delegated_account: &Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         commit_record_seeds_from_delegated_account!(delegated_account),
         &crate::id(),
@@ -138,7 +146,9 @@ pub fn delegate_buffer_pda_from_delegated_account_and_owner_program(
     .0
 }
 
-pub fn undelegate_buffer_pda_from_delegated_account(delegated_account: &Pubkey) -> Pubkey {
+pub fn undelegate_buffer_pda_from_delegated_account(
+    delegated_account: &Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         undelegate_buffer_seeds_from_delegated_account!(delegated_account),
         &crate::id(),

--- a/src/pod_view.rs
+++ b/src/pod_view.rs
@@ -110,7 +110,9 @@ pub trait PodView {
     /// In that case, we could create a "copy" instead of a "view" using this
     /// function that takes care of provided possibly-unaligned_buffer.
     #[cfg(feature = "unit_test_config")]
-    fn try_from_unaligned(unaligned_buffer: &[u8]) -> Result<Self, ProgramError>
+    fn try_from_unaligned(
+        unaligned_buffer: &[u8],
+    ) -> Result<Self, ProgramError>
     where
         Self: Sized;
 }
@@ -129,15 +131,19 @@ impl<T: bytemuck::Pod> PodView for T {
     }
 
     fn try_view_from(buffer: &[u8]) -> Result<&Self, ProgramError> {
-        bytemuck::try_from_bytes(buffer).map_err(|_| ProgramError::InvalidArgument)
+        bytemuck::try_from_bytes(buffer)
+            .map_err(|_| ProgramError::InvalidArgument)
     }
 
     fn try_view_from_mut(buffer: &mut [u8]) -> Result<&mut Self, ProgramError> {
-        bytemuck::try_from_bytes_mut(buffer).map_err(|_| ProgramError::InvalidArgument)
+        bytemuck::try_from_bytes_mut(buffer)
+            .map_err(|_| ProgramError::InvalidArgument)
     }
 
     #[cfg(feature = "unit_test_config")]
-    fn try_from_unaligned(possibly_unaligned_buffer: &[u8]) -> Result<Self, ProgramError> {
+    fn try_from_unaligned(
+        possibly_unaligned_buffer: &[u8],
+    ) -> Result<Self, ProgramError> {
         bytemuck::try_pod_read_unaligned(possibly_unaligned_buffer)
             .map_err(|_| ProgramError::InvalidArgument)
     }

--- a/src/processor/call_handler.rs
+++ b/src/processor/call_handler.rs
@@ -1,18 +1,23 @@
-use crate::args::CallHandlerArgs;
-use crate::ephemeral_balance_seeds_from_payer;
-use crate::error::{INVALID_ESCROW_OWNER, INVALID_ESCROW_PDA};
-use crate::processor::utils::loaders::{
-    load_initialized_validator_fees_vault, load_owned_pda, load_pda, load_signer,
+use borsh::BorshDeserialize;
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    system_program,
 };
 
-use borsh::BorshDeserialize;
-use solana_program::account_info::AccountInfo;
-use solana_program::entrypoint::ProgramResult;
-use solana_program::instruction::{AccountMeta, Instruction};
-use solana_program::program::invoke_signed;
-use solana_program::program_error::ProgramError;
-use solana_program::pubkey::Pubkey;
-use solana_program::system_program;
+use crate::{
+    args::CallHandlerArgs,
+    ephemeral_balance_seeds_from_payer,
+    error::{INVALID_ESCROW_OWNER, INVALID_ESCROW_PDA},
+    processor::utils::loaders::{
+        load_initialized_validator_fees_vault, load_owned_pda, load_pda,
+        load_signer,
+    },
+};
 
 /// Calls a handler on user specified program
 ///
@@ -61,11 +66,17 @@ pub fn process_call_handler(
     // verify account is a signer
     load_signer(validator, "validator")?;
     // verify signer is a registered validator
-    load_initialized_validator_fees_vault(validator, validator_fees_vault, true)?;
+    load_initialized_validator_fees_vault(
+        validator,
+        validator_fees_vault,
+        true,
+    )?;
 
     // verify passed escrow_account derived from escrow authority
-    let escrow_seeds: &[&[u8]] =
-        ephemeral_balance_seeds_from_payer!(escrow_authority_account.key, args.escrow_index);
+    let escrow_seeds: &[&[u8]] = ephemeral_balance_seeds_from_payer!(
+        escrow_authority_account.key,
+        args.escrow_index
+    );
     let escrow_bump = load_pda(
         escrow_account,
         escrow_seeds,
@@ -73,10 +84,17 @@ pub fn process_call_handler(
         true,
         INVALID_ESCROW_PDA,
     )?;
-    load_owned_pda(escrow_account, &system_program::id(), INVALID_ESCROW_OWNER)?;
+    load_owned_pda(
+        escrow_account,
+        &system_program::id(),
+        INVALID_ESCROW_OWNER,
+    )?;
 
     // deduce necessary accounts for CPI
-    let (accounts_meta, handler_accounts): (Vec<AccountMeta>, Vec<AccountInfo>) = other_accounts
+    let (accounts_meta, handler_accounts): (
+        Vec<AccountMeta>,
+        Vec<AccountInfo>,
+    ) = other_accounts
         .iter()
         .chain([escrow_authority_account, escrow_account])
         .filter(|account| account.key != validator.key)

--- a/src/processor/call_handler_v2.rs
+++ b/src/processor/call_handler_v2.rs
@@ -1,18 +1,23 @@
-use crate::args::CallHandlerArgs;
-use crate::ephemeral_balance_seeds_from_payer;
-use crate::error::{INVALID_ESCROW_OWNER, INVALID_ESCROW_PDA};
-use crate::processor::utils::loaders::{
-    load_initialized_validator_fees_vault, load_owned_pda, load_pda, load_signer,
+use borsh::BorshDeserialize;
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    system_program,
 };
 
-use borsh::BorshDeserialize;
-use solana_program::account_info::AccountInfo;
-use solana_program::entrypoint::ProgramResult;
-use solana_program::instruction::{AccountMeta, Instruction};
-use solana_program::program::invoke_signed;
-use solana_program::program_error::ProgramError;
-use solana_program::pubkey::Pubkey;
-use solana_program::system_program;
+use crate::{
+    args::CallHandlerArgs,
+    ephemeral_balance_seeds_from_payer,
+    error::{INVALID_ESCROW_OWNER, INVALID_ESCROW_PDA},
+    processor::utils::loaders::{
+        load_initialized_validator_fees_vault, load_owned_pda, load_pda,
+        load_signer,
+    },
+};
 
 /// Calls a handler on user specified program
 ///
@@ -62,11 +67,17 @@ pub fn process_call_handler_v2(
     // verify account is a signer
     load_signer(validator, "validator")?;
     // verify signer is a registered validator
-    load_initialized_validator_fees_vault(validator, validator_fees_vault, true)?;
+    load_initialized_validator_fees_vault(
+        validator,
+        validator_fees_vault,
+        true,
+    )?;
 
     // verify passed escrow_account derived from escrow authority
-    let escrow_seeds: &[&[u8]] =
-        ephemeral_balance_seeds_from_payer!(escrow_authority_account.key, args.escrow_index);
+    let escrow_seeds: &[&[u8]] = ephemeral_balance_seeds_from_payer!(
+        escrow_authority_account.key,
+        args.escrow_index
+    );
     let escrow_bump = load_pda(
         escrow_account,
         escrow_seeds,
@@ -74,10 +85,17 @@ pub fn process_call_handler_v2(
         true,
         INVALID_ESCROW_PDA,
     )?;
-    load_owned_pda(escrow_account, &system_program::id(), INVALID_ESCROW_OWNER)?;
+    load_owned_pda(
+        escrow_account,
+        &system_program::id(),
+        INVALID_ESCROW_OWNER,
+    )?;
 
     // deduce necessary accounts for CPI
-    let (accounts_meta, handler_accounts): (Vec<AccountMeta>, Vec<AccountInfo>) = other_accounts
+    let (accounts_meta, handler_accounts): (
+        Vec<AccountMeta>,
+        Vec<AccountInfo>,
+    ) = other_accounts
         .iter()
         .chain([source_program, escrow_authority_account, escrow_account])
         .filter(|account| account.key != validator.key)

--- a/src/processor/close_ephemeral_balance.rs
+++ b/src/processor/close_ephemeral_balance.rs
@@ -1,11 +1,12 @@
-use crate::ephemeral_balance_seeds_from_payer;
-use crate::processor::utils::loaders::{load_pda, load_signer};
-use solana_program::msg;
-use solana_program::program::invoke_signed;
-use solana_program::program_error::ProgramError;
-use solana_program::system_instruction::transfer;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program::invoke_signed, program_error::ProgramError, pubkey::Pubkey,
+    system_instruction::transfer, system_program,
+};
+
+use crate::{
+    ephemeral_balance_seeds_from_payer,
+    processor::utils::loaders::{load_pda, load_signer},
 };
 
 /// Process the closing of an ephemeral balance account
@@ -38,7 +39,8 @@ pub fn process_close_ephemeral_balance(
 
     load_signer(payer, "payer")?;
 
-    let ephemeral_balance_seeds: &[&[u8]] = ephemeral_balance_seeds_from_payer!(payer.key, index);
+    let ephemeral_balance_seeds: &[&[u8]] =
+        ephemeral_balance_seeds_from_payer!(payer.key, index);
     let ephemeral_balance_bump = load_pda(
         ephemeral_balance_account,
         ephemeral_balance_seeds,

--- a/src/processor/close_validator_fees_vault.rs
+++ b/src/processor/close_validator_fees_vault.rs
@@ -1,13 +1,18 @@
-use solana_program::msg;
-use solana_program::program_error::ProgramError;
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
-
-use crate::error::DlpError::Unauthorized;
-use crate::processor::utils::loaders::{
-    load_initialized_pda, load_program_upgrade_authority, load_signer,
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program_error::ProgramError, pubkey::Pubkey,
 };
-use crate::processor::utils::pda::close_pda;
-use crate::validator_fees_vault_seeds_from_validator;
+
+use crate::{
+    error::DlpError::Unauthorized,
+    processor::utils::{
+        loaders::{
+            load_initialized_pda, load_program_upgrade_authority, load_signer,
+        },
+        pda::close_pda,
+    },
+    validator_fees_vault_seeds_from_validator,
+};
 
 /// Process the close of the validator fees vault
 ///
@@ -43,7 +48,8 @@ pub fn process_close_validator_fees_vault(
 
     // Check if the admin is the correct one
     let admin_pubkey =
-        load_program_upgrade_authority(&crate::ID, delegation_program_data)?.ok_or(Unauthorized)?;
+        load_program_upgrade_authority(&crate::ID, delegation_program_data)?
+            .ok_or(Unauthorized)?;
     if !admin.key.eq(&admin_pubkey) {
         msg!(
             "Expected admin pubkey: {} but got {}",

--- a/src/processor/delegate_ephemeral_balance.rs
+++ b/src/processor/delegate_ephemeral_balance.rs
@@ -1,12 +1,14 @@
-use crate::args::DelegateEphemeralBalanceArgs;
-use crate::ephemeral_balance_seeds_from_payer;
-use crate::processor::utils::loaders::{load_program, load_signer};
 use borsh::BorshDeserialize;
-use solana_program::program::invoke_signed;
-use solana_program::program_error::ProgramError;
-use solana_program::system_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_instruction,
+    account_info::AccountInfo, entrypoint::ProgramResult,
+    program::invoke_signed, program_error::ProgramError, pubkey::Pubkey,
+    system_instruction, system_program,
+};
+
+use crate::{
+    args::DelegateEphemeralBalanceArgs,
+    ephemeral_balance_seeds_from_payer,
+    processor::utils::loaders::{load_program, load_signer},
 };
 
 /// Delegates an account to transfer lamports which are used to fund it inside
@@ -58,7 +60,8 @@ pub fn process_delegate_ephemeral_balance(
     }
 
     // Set the delegation seeds
-    args.delegate_args.seeds = ephemeral_balance_seeds.iter().map(|s| s.to_vec()).collect();
+    args.delegate_args.seeds =
+        ephemeral_balance_seeds.iter().map(|s| s.to_vec()).collect();
 
     // Generate the ephemeral balance PDA's signer seeds
     let ephemeral_balance_bump_slice = &[ephemeral_balance_bump];
@@ -67,7 +70,10 @@ pub fn process_delegate_ephemeral_balance(
 
     // Assign as owner the delegation program
     invoke_signed(
-        &system_instruction::assign(ephemeral_balance_account.key, &crate::id()),
+        &system_instruction::assign(
+            ephemeral_balance_account.key,
+            &crate::id(),
+        ),
         &[ephemeral_balance_account.clone(), system_program.clone()],
         &[&ephemeral_balance_signer_seeds],
     )?;

--- a/src/processor/fast/commit_diff.rs
+++ b/src/processor/fast/commit_diff.rs
@@ -2,13 +2,12 @@ use borsh::BorshDeserialize;
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_log::log;
 
-use crate::args::{CommitDiffArgsWithoutDiff, SIZE_COMMIT_DIFF_ARGS_WITHOUT_DIFF};
-use crate::processor::fast::{process_commit_state_internal, CommitStateInternalArgs};
-use crate::DiffSet;
-
 use super::NewState;
-
-use crate::{require, require_n_accounts};
+use crate::{
+    args::{CommitDiffArgsWithoutDiff, SIZE_COMMIT_DIFF_ARGS_WITHOUT_DIFF},
+    processor::fast::{process_commit_state_internal, CommitStateInternalArgs},
+    require, require_n_accounts, DiffSet,
+};
 
 /// Commit diff to a delegated PDA
 ///
@@ -64,10 +63,11 @@ pub fn process_commit_diff(
         ProgramError::InvalidInstructionData
     );
 
-    let (diff, data) = data.split_at(data.len() - SIZE_COMMIT_DIFF_ARGS_WITHOUT_DIFF);
+    let (diff, data) =
+        data.split_at(data.len() - SIZE_COMMIT_DIFF_ARGS_WITHOUT_DIFF);
 
-    let args =
-        CommitDiffArgsWithoutDiff::try_from_slice(data).map_err(|_| ProgramError::BorshIoError)?;
+    let args = CommitDiffArgsWithoutDiff::try_from_slice(data)
+        .map_err(|_| ProgramError::BorshIoError)?;
 
     let diffset = DiffSet::try_new_from_borsh_vec(diff)?;
 

--- a/src/processor/fast/commit_diff_from_buffer.rs
+++ b/src/processor/fast/commit_diff_from_buffer.rs
@@ -1,15 +1,13 @@
-use crate::args::CommitStateFromBufferArgs;
-use crate::processor::fast::{process_commit_state_internal, CommitStateInternalArgs};
-use crate::DiffSet;
-
 use borsh::BorshDeserialize;
-use pinocchio::error::ProgramError;
-use pinocchio::AccountView;
-use pinocchio::Address;
-use pinocchio::ProgramResult;
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_log::log;
 
 use super::NewState;
+use crate::{
+    args::CommitStateFromBufferArgs,
+    processor::fast::{process_commit_state_internal, CommitStateInternalArgs},
+    DiffSet,
+};
 
 pub fn process_commit_diff_from_buffer(
     _program_id: &Address,
@@ -22,8 +20,8 @@ pub fn process_commit_diff_from_buffer(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    let args =
-        CommitStateFromBufferArgs::try_from_slice(data).map_err(|_| ProgramError::BorshIoError)?;
+    let args = CommitStateFromBufferArgs::try_from_slice(data)
+        .map_err(|_| ProgramError::BorshIoError)?;
 
     let commit_record_lamports = args.lamports;
     let commit_record_nonce = args.nonce;

--- a/src/processor/fast/commit_finalize.rs
+++ b/src/processor/fast/commit_finalize.rs
@@ -1,12 +1,16 @@
 use pinocchio::{AccountView, Address, ProgramResult};
 use pinocchio_log::log;
 
-use crate::args::CommitFinalizeArgsWithBuffer;
-use crate::processor::fast::internal::{
-    process_commit_finalize_internal, CommitFinalizeInternalArgs,
+use crate::{
+    args::CommitFinalizeArgsWithBuffer,
+    processor::fast::{
+        internal::{
+            process_commit_finalize_internal, CommitFinalizeInternalArgs,
+        },
+        NewState,
+    },
+    require_n_accounts, DiffSet,
 };
-use crate::processor::fast::NewState;
-use crate::{require_n_accounts, DiffSet};
 
 /// Commit a new state, or a diff, directly to the delegated account. Unlike, CommitState and
 /// CommitDiff variants, this instruction does not write to any temporary account first. In other

--- a/src/processor/fast/commit_finalize_from_buffer.rs
+++ b/src/processor/fast/commit_finalize_from_buffer.rs
@@ -1,13 +1,17 @@
 use pinocchio::{AccountView, Address, ProgramResult};
 use pinocchio_log::log;
 
-use crate::args::CommitFinalizeArgs;
-use crate::pod_view::PodView;
-use crate::processor::fast::internal::{
-    process_commit_finalize_internal, CommitFinalizeInternalArgs,
+use crate::{
+    args::CommitFinalizeArgs,
+    pod_view::PodView,
+    processor::fast::{
+        internal::{
+            process_commit_finalize_internal, CommitFinalizeInternalArgs,
+        },
+        NewState,
+    },
+    require_n_accounts, DiffSet,
 };
-use crate::processor::fast::NewState;
-use crate::{require_n_accounts, DiffSet};
 
 /// Commit a new state of a delegated PDA
 ///

--- a/src/processor/fast/commit_state.rs
+++ b/src/processor/fast/commit_state.rs
@@ -1,25 +1,31 @@
 use borsh::BorshDeserialize;
-use pinocchio::address::address_eq;
-use pinocchio::cpi::Signer;
-use pinocchio::instruction::seeds;
-use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio::{
+    address::address_eq, cpi::Signer, error::ProgramError, instruction::seeds,
+    AccountView, Address, ProgramResult,
+};
 use pinocchio_log::log;
 use pinocchio_system::instructions as system;
 
-use crate::args::CommitStateArgs;
-use crate::error::DlpError;
-use crate::processor::fast::utils::{
-    pda::create_pda,
-    requires::{
-        require_initialized_delegation_metadata, require_initialized_delegation_record,
-        require_initialized_validator_fees_vault, require_owned_pda, require_program_config,
-        require_signer, require_uninitialized_pda, CommitRecordCtx, CommitStateAccountCtx,
-    },
-};
-use crate::state::{CommitRecord, DelegationMetadata, DelegationRecord, ProgramConfig};
-use crate::{merge_diff_copy, pda, DiffSet};
-
 use super::to_pinocchio_program_error;
+use crate::{
+    args::CommitStateArgs,
+    error::DlpError,
+    merge_diff_copy, pda,
+    processor::fast::utils::{
+        pda::create_pda,
+        requires::{
+            require_initialized_delegation_metadata,
+            require_initialized_delegation_record,
+            require_initialized_validator_fees_vault, require_owned_pda,
+            require_program_config, require_signer, require_uninitialized_pda,
+            CommitRecordCtx, CommitStateAccountCtx,
+        },
+    },
+    state::{
+        CommitRecord, DelegationMetadata, DelegationRecord, ProgramConfig,
+    },
+    DiffSet,
+};
 
 /// Commit a new state of a delegated PDA
 ///
@@ -55,7 +61,8 @@ pub fn process_commit_state(
     accounts: &[AccountView],
     data: &[u8],
 ) -> ProgramResult {
-    let args = CommitStateArgs::try_from_slice(data).map_err(|_| ProgramError::BorshIoError)?;
+    let args = CommitStateArgs::try_from_slice(data)
+        .map_err(|_| ProgramError::BorshIoError)?;
 
     let commit_record_lamports = args.lamports;
     let commit_record_nonce = args.nonce;
@@ -136,13 +143,20 @@ pub(crate) fn process_commit_state_internal(
         args.delegation_metadata_account,
         true,
     )?;
-    require_initialized_validator_fees_vault(args.validator, args.validator_fees_vault, false)?;
+    require_initialized_validator_fees_vault(
+        args.validator,
+        args.validator_fees_vault,
+        false,
+    )?;
 
     // Read delegation metadata
-    let mut delegation_metadata_data = args.delegation_metadata_account.try_borrow_mut()?;
+    let mut delegation_metadata_data =
+        args.delegation_metadata_account.try_borrow_mut()?;
     let mut delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     // To preserve correct history of account updates we require sequential commits
     if args.commit_record_nonce != delegation_metadata.last_update_nonce + 1 {
@@ -170,8 +184,10 @@ pub(crate) fn process_commit_state_internal(
     // Load delegation record
     let delegation_record_data = args.delegation_record_account.try_borrow()?;
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     // Check that the authority is allowed to commit
     if !address_eq(
@@ -215,8 +231,10 @@ pub(crate) fn process_commit_state_internal(
     if has_program_config {
         let program_config_data = args.program_config_account.try_borrow()?;
 
-        let program_config = ProgramConfig::try_from_bytes_with_discriminator(&program_config_data)
-            .map_err(to_pinocchio_program_error)?;
+        let program_config = ProgramConfig::try_from_bytes_with_discriminator(
+            &program_config_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
         if !program_config
             .approved_validators
             .contains(&args.validator.address().to_bytes().into())
@@ -291,7 +309,9 @@ pub(crate) fn process_commit_state_internal(
     let mut commit_state_data = args.commit_state_account.try_borrow_mut()?;
 
     match args.commit_state_bytes {
-        NewState::FullBytes(bytes) => (*commit_state_data).copy_from_slice(bytes),
+        NewState::FullBytes(bytes) => {
+            (*commit_state_data).copy_from_slice(bytes)
+        }
         NewState::Diff(diff) => {
             let original_data = args.delegated_account.try_borrow()?;
             merge_diff_copy(&mut commit_state_data, &original_data, &diff)?;

--- a/src/processor/fast/commit_state_from_buffer.rs
+++ b/src/processor/fast/commit_state_from_buffer.rs
@@ -1,13 +1,11 @@
-use crate::args::CommitStateFromBufferArgs;
-use crate::processor::fast::{process_commit_state_internal, CommitStateInternalArgs};
-
 use borsh::BorshDeserialize;
-use pinocchio::error::ProgramError;
-use pinocchio::AccountView;
-use pinocchio::Address;
-use pinocchio::ProgramResult;
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 
 use super::NewState;
+use crate::{
+    args::CommitStateFromBufferArgs,
+    processor::fast::{process_commit_state_internal, CommitStateInternalArgs},
+};
 
 pub fn process_commit_state_from_buffer(
     _program_id: &Address,
@@ -20,8 +18,8 @@ pub fn process_commit_state_from_buffer(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    let args =
-        CommitStateFromBufferArgs::try_from_slice(data).map_err(|_| ProgramError::BorshIoError)?;
+    let args = CommitStateFromBufferArgs::try_from_slice(data)
+        .map_err(|_| ProgramError::BorshIoError)?;
 
     let commit_record_lamports = args.lamports;
     let commit_record_nonce = args.nonce;

--- a/src/processor/fast/delegate.rs
+++ b/src/processor/fast/delegate.rs
@@ -1,23 +1,34 @@
 use borsh::BorshDeserialize;
-use pinocchio::address::address_eq;
-use pinocchio::cpi::{Seed, Signer};
-use pinocchio::sysvars::clock::Clock;
-use pinocchio::sysvars::Sysvar;
-use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio::{
+    address::address_eq,
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    AccountView, Address, ProgramResult,
+};
 use pinocchio_log::log;
 use pinocchio_system::instructions as system;
 
-use crate::args::DelegateArgs;
-use crate::consts::{DEFAULT_VALIDATOR_IDENTITY, RENT_EXCEPTION_ZERO_BYTES_LAMPORTS};
-use crate::error::DlpError;
-use crate::pda;
-use crate::processor::fast::to_pinocchio_program_error;
-use crate::processor::fast::utils::{pda::create_pda, requires::require_uninitialized_pda};
-use crate::processor::utils::curve::is_on_curve_fast;
-use crate::state::{DelegationMetadata, DelegationRecord};
-
-use crate::processor::fast::utils::requires::{
-    require_owned_pda, require_pda, require_signer, DelegationMetadataCtx, DelegationRecordCtx,
+use crate::{
+    args::DelegateArgs,
+    consts::{DEFAULT_VALIDATOR_IDENTITY, RENT_EXCEPTION_ZERO_BYTES_LAMPORTS},
+    error::DlpError,
+    pda,
+    processor::{
+        fast::{
+            to_pinocchio_program_error,
+            utils::{
+                pda::create_pda,
+                requires::{
+                    require_owned_pda, require_pda, require_signer,
+                    require_uninitialized_pda, DelegationMetadataCtx,
+                    DelegationRecordCtx,
+                },
+            },
+        },
+        utils::curve::is_on_curve_fast,
+    },
+    state::{DelegationMetadata, DelegationRecord},
 };
 
 /// Delegates an account
@@ -77,7 +88,11 @@ fn process_delegate_inner(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    require_owned_pda(delegated_account, &crate::fast::ID, "delegated account")?;
+    require_owned_pda(
+        delegated_account,
+        &crate::fast::ID,
+        "delegated account",
+    )?;
 
     // Check that payer and delegated_account are signers, this ensures the instruction is being called from CPI
     require_signer(payer, "payer")?;
@@ -123,12 +138,14 @@ fn process_delegate_inner(
         DelegationMetadataCtx,
     )?;
 
-    let args =
-        DelegateArgs::try_from_slice(data).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let args = DelegateArgs::try_from_slice(data)
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
     if !allow_system_program_validator {
         if let Some(validator) = args.validator {
             if validator.to_bytes() == pinocchio_system::ID.to_bytes() {
-                return Err(DlpError::DelegationToSystemProgramNotAllowed.into());
+                return Err(
+                    DlpError::DelegationToSystemProgramNotAllowed.into()
+                );
             }
         }
     }
@@ -137,11 +154,12 @@ fn process_delegate_inner(
     // If the owner is the system program, we check if the account is derived from the delegation program,
     // allowing delegation of escrow accounts
     if !is_on_curve_fast(delegated_account.address()) {
-        let program_id = if address_eq(owner_program.address(), &pinocchio_system::ID) {
-            &crate::fast::ID
-        } else {
-            owner_program.address()
-        };
+        let program_id =
+            if address_eq(owner_program.address(), &pinocchio_system::ID) {
+                &crate::fast::ID
+            } else {
+                owner_program.address()
+            };
         let seeds_to_validate: &[&[u8]] = match args.seeds.len() {
             1 => &[&args.seeds[0]],
             2 => &[&args.seeds[0], &args.seeds[1]],
@@ -188,7 +206,8 @@ fn process_delegate_inner(
             ],
             _ => return Err(DlpError::TooManySeeds.into()),
         };
-        let derived_pda = Address::find_program_address(seeds_to_validate, program_id).0;
+        let derived_pda =
+            Address::find_program_address(seeds_to_validate, program_id).0;
 
         if !address_eq(&derived_pda, delegated_account.address()) {
             log!("Expected delegated PDA to be: ");
@@ -220,7 +239,8 @@ fn process_delegate_inner(
         lamports: delegated_account.lamports(),
     };
 
-    let mut delegation_record_data = delegation_record_account.try_borrow_mut()?;
+    let mut delegation_record_data =
+        delegation_record_account.try_borrow_mut()?;
     delegation_record
         .to_bytes_with_discriminator(&mut delegation_record_data)
         .map_err(to_pinocchio_program_error)?;
@@ -246,7 +266,8 @@ fn process_delegate_inner(
     )?;
 
     // Copy the seeds to the delegated metadata PDA
-    let mut delegation_metadata_data = delegation_metadata_account.try_borrow_mut()?;
+    let mut delegation_metadata_data =
+        delegation_metadata_account.try_borrow_mut()?;
     delegation_metadata
         .to_bytes_with_discriminator(&mut delegation_metadata_data.as_mut())
         .map_err(to_pinocchio_program_error)?;

--- a/src/processor/fast/finalize.rs
+++ b/src/processor/fast/finalize.rs
@@ -1,19 +1,26 @@
-use pinocchio::address::{address_eq, Address};
-use pinocchio::error::ProgramError;
-use pinocchio::AccountView;
-use pinocchio::ProgramResult;
+use pinocchio::{
+    address::{address_eq, Address},
+    error::ProgramError,
+    AccountView, ProgramResult,
+};
 use pinocchio_log::log;
 
-use crate::error::DlpError;
-use crate::processor::fast::utils::pda::close_pda;
-use crate::processor::fast::utils::requires::{
-    is_uninitialized_account, require_initialized_commit_record, require_initialized_commit_state,
-    require_initialized_delegation_metadata, require_initialized_delegation_record,
-    require_initialized_validator_fees_vault, require_owned_pda, require_signer,
-};
-use crate::state::{CommitRecord, DelegationMetadata, DelegationRecord};
-
 use super::to_pinocchio_program_error;
+use crate::{
+    error::DlpError,
+    processor::fast::utils::{
+        pda::close_pda,
+        requires::{
+            is_uninitialized_account, require_initialized_commit_record,
+            require_initialized_commit_state,
+            require_initialized_delegation_metadata,
+            require_initialized_delegation_record,
+            require_initialized_validator_fees_vault, require_owned_pda,
+            require_signer,
+        },
+    },
+    state::{CommitRecord, DelegationMetadata, DelegationRecord},
+};
 
 /// Finalize a committed state, after validation, to a delegated account
 ///
@@ -60,20 +67,44 @@ pub fn process_finalize(
     };
 
     require_signer(validator, "validator")?;
-    require_owned_pda(delegated_account, &crate::fast::ID, "delegated account")?;
-    require_initialized_delegation_record(delegated_account, delegation_record_account, true)?;
-    require_initialized_delegation_metadata(delegated_account, delegation_metadata_account, true)?;
-    require_initialized_validator_fees_vault(validator, validator_fees_vault, true)?;
+    require_owned_pda(
+        delegated_account,
+        &crate::fast::ID,
+        "delegated account",
+    )?;
+    require_initialized_delegation_record(
+        delegated_account,
+        delegation_record_account,
+        true,
+    )?;
+    require_initialized_delegation_metadata(
+        delegated_account,
+        delegation_metadata_account,
+        true,
+    )?;
+    require_initialized_validator_fees_vault(
+        validator,
+        validator_fees_vault,
+        true,
+    )?;
 
-    let require_cs =
-        require_initialized_commit_state(delegated_account, commit_state_account, true);
-    let require_cr =
-        require_initialized_commit_record(delegated_account, commit_record_account, true);
+    let require_cs = require_initialized_commit_state(
+        delegated_account,
+        commit_state_account,
+        true,
+    );
+    let require_cr = require_initialized_commit_record(
+        delegated_account,
+        commit_record_account,
+        true,
+    );
 
     // Since finalize instructions are typically bundled, we return without error
     // if there is nothing to be finalized, so that correct finalizes are executed
-    if let (Err(ProgramError::InvalidAccountOwner), Err(ProgramError::InvalidAccountOwner)) =
-        (&require_cs, &require_cr)
+    if let (
+        Err(ProgramError::InvalidAccountOwner),
+        Err(ProgramError::InvalidAccountOwner),
+    ) = (&require_cs, &require_cr)
     {
         if is_uninitialized_account(commit_state_account)
             && is_uninitialized_account(commit_record_account)
@@ -86,20 +117,27 @@ pub fn process_finalize(
     require_cr?;
 
     // Load delegation metadata
-    let mut delegation_metadata_data = delegation_metadata_account.try_borrow_mut()?;
+    let mut delegation_metadata_data =
+        delegation_metadata_account.try_borrow_mut()?;
     let mut delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
-    let mut delegation_record_data = delegation_record_account.try_borrow_mut()?;
+    let mut delegation_record_data =
+        delegation_record_account.try_borrow_mut()?;
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator_mut(&mut delegation_record_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationRecord::try_from_bytes_with_discriminator_mut(
+            &mut delegation_record_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     // Load commit record
     let commit_record_data = commit_record_account.try_borrow()?;
-    let commit_record = CommitRecord::try_from_bytes_with_discriminator(&commit_record_data)
-        .map_err(to_pinocchio_program_error)?;
+    let commit_record =
+        CommitRecord::try_from_bytes_with_discriminator(&commit_record_data)
+            .map_err(to_pinocchio_program_error)?;
 
     // Check that the commit record is the right one
     if !address_eq(
@@ -187,7 +225,8 @@ fn settle_lamports_balance(
             .ok_or(DlpError::Overflow)?,
     );
 
-    transfer_destination.set_lamports(transfer_destination.lamports() + transfer_lamports);
+    transfer_destination
+        .set_lamports(transfer_destination.lamports() + transfer_lamports);
 
     Ok(())
 }

--- a/src/processor/fast/internal/commit_finalize_internal.rs
+++ b/src/processor/fast/internal/commit_finalize_internal.rs
@@ -1,15 +1,20 @@
-use pinocchio::address::{address_eq, PDA_MARKER};
-use pinocchio::{error::ProgramError, AccountView, Address};
+use pinocchio::{
+    address::{address_eq, PDA_MARKER},
+    error::ProgramError,
+    AccountView, Address,
+};
 use pinocchio_log::log;
 
-use crate::args::CommitBumps;
-use crate::error::DlpError;
-use crate::pod_view::PodView;
-use crate::processor::fast::NewState;
-use crate::state::{DelegationMetadataFast, DelegationRecord};
 use crate::{
-    apply_diff_in_place, pda, require, require_eq, require_eq_keys, require_ge,
+    apply_diff_in_place,
+    args::CommitBumps,
+    error::DlpError,
+    pda,
+    pod_view::PodView,
+    processor::fast::NewState,
+    require, require_eq, require_eq_keys, require_ge,
     require_initialized_pda_fast, require_owned_by, require_signer,
+    state::{DelegationMetadataFast, DelegationRecord},
 };
 
 /// Arguments for the commit state internal function
@@ -72,7 +77,9 @@ pub(crate) fn process_commit_finalize_internal(
 
     // validate and update metadata
     {
-        let mut metadata = DelegationMetadataFast::from_account(args.delegation_metadata_account)?;
+        let mut metadata = DelegationMetadataFast::from_account(
+            args.delegation_metadata_account,
+        )?;
 
         let prev_id = metadata.replace_last_update_nonce(args.commit_id);
 
@@ -85,7 +92,8 @@ pub(crate) fn process_commit_finalize_internal(
     }
 
     let delegation_record_data = args.delegation_record_account.try_borrow()?;
-    let delegation_record = DelegationRecord::try_view_from(&delegation_record_data.as_ref()[8..])?;
+    let delegation_record =
+        DelegationRecord::try_view_from(&delegation_record_data.as_ref()[8..])?;
 
     // Check that the authority is allowed to commit
     require_eq_keys!(
@@ -115,7 +123,9 @@ pub(crate) fn process_commit_finalize_internal(
     // copy the new state to the delegated account
     let mut delegated_account_data = args.delegated_account.try_borrow_mut()?;
     match args.new_state {
-        NewState::FullBytes(bytes) => (*delegated_account_data).copy_from_slice(bytes),
+        NewState::FullBytes(bytes) => {
+            (*delegated_account_data).copy_from_slice(bytes)
+        }
         NewState::Diff(diff) => {
             apply_diff_in_place(&mut delegated_account_data, &diff)?;
         }

--- a/src/processor/fast/undelegate.rs
+++ b/src/processor/fast/undelegate.rs
@@ -1,17 +1,6 @@
-use crate::consts::{COMMIT_FEE_LAMPORTS, EXTERNAL_UNDELEGATE_DISCRIMINATOR, SESSION_FEE_LAMPORTS};
-use crate::error::DlpError;
-use crate::pda;
-use crate::processor::fast::utils::{
-    pda::{close_pda, close_pda_with_fees, create_pda},
-    requires::{
-        require_uninitialized_pda, CommitRecordCtx, CommitStateAccountCtx, UndelegateBufferCtx,
-    },
-};
-use crate::state::{DelegationMetadata, DelegationRecord};
 use pinocchio::{
     address::{address_eq, Address},
-    cpi::invoke_signed,
-    cpi::Signer,
+    cpi::{invoke_signed, Signer},
     error::ProgramError,
     instruction::{seeds, InstructionAccount, InstructionView},
     sysvars::{rent::Rent, Sysvar},
@@ -20,16 +9,33 @@ use pinocchio::{
 use pinocchio_log::log;
 use pinocchio_system::instructions as system;
 
-#[cfg(feature = "log-cost")]
-use crate::compute;
-
 use super::{
     to_pinocchio_program_error,
     utils::requires::{
-        require_initialized_delegation_metadata, require_initialized_delegation_record,
-        require_initialized_protocol_fees_vault, require_initialized_validator_fees_vault,
-        require_owned_pda, require_signer,
+        require_initialized_delegation_metadata,
+        require_initialized_delegation_record,
+        require_initialized_protocol_fees_vault,
+        require_initialized_validator_fees_vault, require_owned_pda,
+        require_signer,
     },
+};
+#[cfg(feature = "log-cost")]
+use crate::compute;
+use crate::{
+    consts::{
+        COMMIT_FEE_LAMPORTS, EXTERNAL_UNDELEGATE_DISCRIMINATOR,
+        SESSION_FEE_LAMPORTS,
+    },
+    error::DlpError,
+    pda,
+    processor::fast::utils::{
+        pda::{close_pda, close_pda_with_fees, create_pda},
+        requires::{
+            require_uninitialized_pda, CommitRecordCtx, CommitStateAccountCtx,
+            UndelegateBufferCtx,
+        },
+    },
+    state::{DelegationMetadata, DelegationRecord},
 };
 
 /// Undelegate a delegated account
@@ -87,11 +93,27 @@ pub fn process_undelegate(
 
     // Check accounts
     require_signer(validator, "validator")?;
-    require_owned_pda(delegated_account, &crate::fast::ID, "delegated account")?;
-    require_initialized_delegation_record(delegated_account, delegation_record_account, true)?;
-    require_initialized_delegation_metadata(delegated_account, delegation_metadata_account, true)?;
+    require_owned_pda(
+        delegated_account,
+        &crate::fast::ID,
+        "delegated account",
+    )?;
+    require_initialized_delegation_record(
+        delegated_account,
+        delegation_record_account,
+        true,
+    )?;
+    require_initialized_delegation_metadata(
+        delegated_account,
+        delegation_metadata_account,
+        true,
+    )?;
     require_initialized_protocol_fees_vault(fees_vault, true)?;
-    require_initialized_validator_fees_vault(validator, validator_fees_vault, true)?;
+    require_initialized_validator_fees_vault(
+        validator,
+        validator_fees_vault,
+        true,
+    )?;
 
     // Make sure there is no pending commits to be finalized before this call
     require_uninitialized_pda(
@@ -112,8 +134,10 @@ pub fn process_undelegate(
     // Load delegation record
     let delegation_record_data = delegation_record_account.try_borrow()?;
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     // Check passed owner and owner stored in the delegation record match
     if !address_eq(
@@ -130,13 +154,17 @@ pub fn process_undelegate(
     // Load delegated account metadata
     let delegation_metadata_data = delegation_metadata_account.try_borrow()?;
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
     let delegation_last_update_nonce = delegation_metadata.last_update_nonce;
 
     // Check if the delegated account is undelegatable
     if !delegation_metadata.is_undelegatable {
-        log!("delegation metadata indicates the account is not undelegatable : ");
+        log!(
+            "delegation metadata indicates the account is not undelegatable : "
+        );
         delegation_metadata_account.address().log();
         return Err(DlpError::NotUndelegatable.into());
     }
@@ -150,7 +178,9 @@ pub fn process_undelegate(
         Address::from(delegation_metadata.rent_payer.to_bytes()).log();
         log!("but got : ");
         rent_reimbursement.address().log();
-        return Err(DlpError::InvalidReimbursementAddressForDelegationRent.into());
+        return Err(
+            DlpError::InvalidReimbursementAddressForDelegationRent.into()
+        );
     }
 
     // Dropping delegation references
@@ -276,15 +306,17 @@ pub(crate) fn process_undelegation_with_cpi(
     }
 
     // Check that the owner program properly moved the state back into the original account during CPI
-    if delegated_account.try_borrow()?.as_ref() != undelegate_buffer_account.try_borrow()?.as_ref()
+    if delegated_account.try_borrow()?.as_ref()
+        != undelegate_buffer_account.try_borrow()?.as_ref()
     {
         return Err(DlpError::InvalidAccountDataAfterCPI.into());
     }
 
     // Return the extra lamports to the delegated account
-    let delegated_account_extra_lamports = delegated_account_lamports_before_close
-        .checked_sub(delegated_account_min_rent)
-        .ok_or(DlpError::Overflow)?;
+    let delegated_account_extra_lamports =
+        delegated_account_lamports_before_close
+            .checked_sub(delegated_account_min_rent)
+            .ok_or(DlpError::Overflow)?;
 
     system::Transfer {
         from: validator,
@@ -318,7 +350,11 @@ fn cpi_external_undelegate(
         data: &data,
         accounts: &[
             InstructionAccount::new(delegated_account.address(), true, false),
-            InstructionAccount::new(undelegate_buffer_account.address(), true, true),
+            InstructionAccount::new(
+                undelegate_buffer_account.address(),
+                true,
+                true,
+            ),
             InstructionAccount::new(payer.address(), true, true),
             InstructionAccount::new(system_program.address(), false, false),
         ],
@@ -349,8 +385,8 @@ fn process_delegation_cleanup(
         .checked_mul(commit_count)
         .ok_or(DlpError::Overflow)?;
     let total_fee_requested = commit_fee + SESSION_FEE_LAMPORTS;
-    let total_lamports =
-        delegation_record_account.lamports() + delegation_metadata_account.lamports();
+    let total_lamports = delegation_record_account.lamports()
+        + delegation_metadata_account.lamports();
     let mut fee_remaining = total_fee_requested.min(total_lamports);
     close_pda_with_fees(
         delegation_record_account,

--- a/src/processor/fast/undelegate_confined_account.rs
+++ b/src/processor/fast/undelegate_confined_account.rs
@@ -1,19 +1,23 @@
-use crate::error::DlpError;
-use crate::processor::fast::utils::requires::require_authorization;
-use crate::processor::fast::utils::{
-    pda::{close_pda, create_pda},
-    requires::{
-        require_initialized_delegation_metadata, require_initialized_delegation_record,
-        require_owned_pda, require_signer, require_uninitialized_pda, UndelegateBufferCtx,
-    },
-};
-use crate::state::{DelegationMetadata, DelegationRecord};
-use crate::{pda, require_eq_keys};
 use pinocchio::{
-    cpi::Signer, error::ProgramError, instruction::seeds, AccountView, Address, ProgramResult,
+    cpi::Signer, error::ProgramError, instruction::seeds, AccountView, Address,
+    ProgramResult,
 };
 
 use super::{process_undelegation_with_cpi, to_pinocchio_program_error};
+use crate::{
+    error::DlpError,
+    pda,
+    processor::fast::utils::{
+        pda::{close_pda, create_pda},
+        requires::{
+            require_authorization, require_initialized_delegation_metadata,
+            require_initialized_delegation_record, require_owned_pda,
+            require_signer, require_uninitialized_pda, UndelegateBufferCtx,
+        },
+    },
+    require_eq_keys,
+    state::{DelegationMetadata, DelegationRecord},
+};
 
 /// Admin-only undelegation for confined accounts (authority == system program)
 /// Accounts:
@@ -43,20 +47,36 @@ pub fn process_undelegate_confined_account(
     require_authorization(delegation_program_data, admin)?;
 
     // Basic checks
-    require_owned_pda(delegated_account, &crate::fast::ID, "delegated account")?;
-    require_initialized_delegation_record(delegated_account, delegation_record_account, true)?;
-    require_initialized_delegation_metadata(delegated_account, delegation_metadata_account, true)?;
+    require_owned_pda(
+        delegated_account,
+        &crate::fast::ID,
+        "delegated account",
+    )?;
+    require_initialized_delegation_record(
+        delegated_account,
+        delegation_record_account,
+        true,
+    )?;
+    require_initialized_delegation_metadata(
+        delegated_account,
+        delegation_metadata_account,
+        true,
+    )?;
 
     // Load delegation record
     let delegation_record_data = delegation_record_account.try_borrow()?;
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     let delegation_metadata_data = delegation_metadata_account.try_borrow()?;
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_data)
-            .map_err(to_pinocchio_program_error)?;
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
 
     // Confined account: authority must be system program
     require_eq_keys!(

--- a/src/processor/fast/utils/pda.rs
+++ b/src/processor/fast/utils/pda.rs
@@ -1,9 +1,8 @@
-use pinocchio::cpi::Signer;
-use pinocchio::sysvars::rent::Rent;
-use pinocchio::sysvars::Sysvar;
-use pinocchio::AccountView;
-use pinocchio::Address;
-use pinocchio::ProgramResult;
+use pinocchio::{
+    cpi::Signer,
+    sysvars::{rent::Rent, Sysvar},
+    AccountView, Address, ProgramResult,
+};
 use pinocchio_system::instructions as system;
 
 use crate::consts::PROTOCOL_FEES_PERCENTAGE;
@@ -64,10 +63,14 @@ pub(crate) fn create_pda(
 
 /// Close PDA
 #[inline(always)]
-pub(crate) fn close_pda(target_account: &AccountView, destination: &AccountView) -> ProgramResult {
+pub(crate) fn close_pda(
+    target_account: &AccountView,
+    destination: &AccountView,
+) -> ProgramResult {
     // Transfer tokens from the account to the destination.
 
-    destination.set_lamports(destination.lamports() + target_account.lamports());
+    destination
+        .set_lamports(destination.lamports() + target_account.lamports());
     target_account.set_lamports(0);
 
     unsafe {
@@ -98,10 +101,12 @@ pub(crate) fn close_pda_with_fees(
         let validator_fee = fee_taken - protocol_fee;
 
         fees_vault.set_lamports(fees_vault.lamports() + protocol_fee);
-        validator_fees_vault.set_lamports(validator_fees_vault.lamports() + validator_fee);
+        validator_fees_vault
+            .set_lamports(validator_fees_vault.lamports() + validator_fee);
     }
 
-    rent_reimbursement.set_lamports(rent_reimbursement.lamports() + destination_amount);
+    rent_reimbursement
+        .set_lamports(rent_reimbursement.lamports() + destination_amount);
     target_account.set_lamports(0);
 
     unsafe {

--- a/src/processor/fast/utils/requires.rs
+++ b/src/processor/fast/utils/requires.rs
@@ -1,10 +1,17 @@
-use pinocchio::address::{address_eq, Address};
-use pinocchio::error::ProgramError;
-use pinocchio::AccountView;
+use pinocchio::{
+    address::{address_eq, Address},
+    error::ProgramError,
+    AccountView,
+};
 use pinocchio_log::log;
 
-use crate::error::DlpError;
-use crate::pda::{self, program_config_from_program_id, validator_fees_vault_pda_from_validator};
+use crate::{
+    error::DlpError,
+    pda::{
+        self, program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+};
 
 // require true
 #[macro_export]
@@ -142,10 +149,14 @@ macro_rules! require_n_accounts {
                     $n,
                     $accounts.len()
                 );
-                return Err(pinocchio::error::ProgramError::NotEnoughAccountKeys);
+                return Err(
+                    pinocchio::error::ProgramError::NotEnoughAccountKeys,
+                );
             }
-            core::cmp::Ordering::Equal => TryInto::<&[_; $n]>::try_into($accounts)
-                .map_err(|_| $crate::error::DlpError::InfallibleError)?,
+            core::cmp::Ordering::Equal => {
+                TryInto::<&[_; $n]>::try_into($accounts)
+                    .map_err(|_| $crate::error::DlpError::InfallibleError)?
+            }
             core::cmp::Ordering::Greater => {
                 pinocchio_log::log!(
                     "Need {} accounts, but got more ({}) accounts",
@@ -337,7 +348,10 @@ pub fn require_owned_pda(
 /// Errors if:
 /// - Account is not a signer.
 #[inline(always)]
-pub fn require_signer(info: &AccountView, label: &str) -> Result<(), ProgramError> {
+pub fn require_signer(
+    info: &AccountView,
+    label: &str,
+) -> Result<(), ProgramError> {
     if !info.is_signer() {
         log!("Account needs to be signer {}: ", label);
         info.address().log();
@@ -378,7 +392,8 @@ pub fn require_pda(
 /// - Owner is the system program.
 /// - Data is empty.
 pub fn is_uninitialized_account(info: &AccountView) -> bool {
-    address_eq(unsafe { info.owner() }, &pinocchio_system::ID) && info.is_data_empty()
+    address_eq(unsafe { info.owner() }, &pinocchio_system::ID)
+        && info.is_data_empty()
 }
 
 /// Errors if:
@@ -479,7 +494,11 @@ pub fn require_initialized_pda(
 /// - Account is not executable.
 #[inline(always)]
 #[allow(dead_code)]
-pub fn require_program(info: &AccountView, key: &Address, label: &str) -> Result<(), ProgramError> {
+pub fn require_program(
+    info: &AccountView,
+    key: &Address,
+    label: &str,
+) -> Result<(), ProgramError> {
     if !address_eq(info.address(), key) {
         log!("Invalid program account {}: ", label);
         info.address().log();
@@ -519,9 +538,11 @@ pub fn require_initialized_validator_fees_vault(
     validator_fees_vault: &AccountView,
     is_writable: bool,
 ) -> Result<(), ProgramError> {
-    let pda = validator_fees_vault_pda_from_validator(&validator.address().to_bytes().into())
-        .to_bytes()
-        .into();
+    let pda = validator_fees_vault_pda_from_validator(
+        &validator.address().to_bytes().into(),
+    )
+    .to_bytes()
+    .into();
     if !address_eq(validator_fees_vault.address(), &pda) {
         log!("Invalid validator fees vault PDA, expected: ");
         pda.log();
@@ -721,7 +742,8 @@ define_uninitialized_ctx!(
     label = "delegation metadata",
     invalid_seeds = DlpError::DelegationMetadataInvalidSeeds,
     invalid_account_owner = DlpError::DelegationMetadataInvalidAccountOwner,
-    account_already_initialized = DlpError::DelegationMetadataAlreadyInitialized,
+    account_already_initialized =
+        DlpError::DelegationMetadataAlreadyInitialized,
     immutable = DlpError::DelegationMetadataImmutable
 );
 
@@ -743,7 +765,9 @@ pub fn require_authorization(
         let _ = program_data;
 
         require_eq_keys!(
-            &Address::from(crate::consts::DEFAULT_VALIDATOR_IDENTITY.to_bytes()),
+            &Address::from(
+                crate::consts::DEFAULT_VALIDATOR_IDENTITY.to_bytes()
+            ),
             admin.address(),
             ProgramError::IncorrectAuthority
         );
@@ -778,10 +802,11 @@ pub fn require_authorization(
             && data[0] == PROGRAM_DATA
             && data[offset_of_upgrade_authority_address] == OPTION_SOME
         {
-            let bytes = &data
-                [offset_of_upgrade_authority_address + 1..offset_of_upgrade_authority_address + 33];
+            let bytes = &data[offset_of_upgrade_authority_address + 1
+                ..offset_of_upgrade_authority_address + 33];
 
-            let upgrade_authority_address = unsafe { &*(bytes.as_ptr() as *const Address) };
+            let upgrade_authority_address =
+                unsafe { &*(bytes.as_ptr() as *const Address) };
 
             require_eq_keys!(
                 upgrade_authority_address,

--- a/src/processor/init_protocol_fees_vault.rs
+++ b/src/processor/init_protocol_fees_vault.rs
@@ -1,11 +1,15 @@
-use solana_program::program_error::ProgramError;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+    account_info::AccountInfo, entrypoint::ProgramResult,
+    program_error::ProgramError, pubkey::Pubkey, system_program,
 };
 
-use crate::fees_vault_seeds;
-use crate::processor::utils::loaders::{load_program, load_signer, load_uninitialized_pda};
-use crate::processor::utils::pda::create_pda;
+use crate::{
+    fees_vault_seeds,
+    processor::utils::{
+        loaders::{load_program, load_signer, load_uninitialized_pda},
+        pda::create_pda,
+    },
+};
 
 /// Initialize the global fees vault
 ///

--- a/src/processor/init_validator_fees_vault.rs
+++ b/src/processor/init_validator_fees_vault.rs
@@ -1,15 +1,19 @@
-use solana_program::msg;
-use solana_program::program_error::ProgramError;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program_error::ProgramError, pubkey::Pubkey, system_program,
 };
 
-use crate::error::DlpError::Unauthorized;
-use crate::processor::utils::loaders::{
-    load_program, load_program_upgrade_authority, load_signer, load_uninitialized_pda,
+use crate::{
+    error::DlpError::Unauthorized,
+    processor::utils::{
+        loaders::{
+            load_program, load_program_upgrade_authority, load_signer,
+            load_uninitialized_pda,
+        },
+        pda::create_pda,
+    },
+    validator_fees_vault_seeds_from_validator,
 };
-use crate::processor::utils::pda::create_pda;
-use crate::validator_fees_vault_seeds_from_validator;
 
 /// Process the initialization of the validator fees vault
 ///
@@ -49,7 +53,8 @@ pub fn process_init_validator_fees_vault(
 
     // Check if the admin is the correct one
     let admin_pubkey =
-        load_program_upgrade_authority(&crate::ID, delegation_program_data)?.ok_or(Unauthorized)?;
+        load_program_upgrade_authority(&crate::ID, delegation_program_data)?
+            .ok_or(Unauthorized)?;
     if !admin.key.eq(&admin_pubkey) {
         msg!(
             "Expected admin pubkey: {} but got {}",

--- a/src/processor/protocol_claim_fees.rs
+++ b/src/processor/protocol_claim_fees.rs
@@ -1,11 +1,15 @@
-use crate::error::DlpError::Unauthorized;
-use crate::processor::utils::loaders::{
-    load_initialized_protocol_fees_vault, load_program_upgrade_authority, load_signer,
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program_error::ProgramError, pubkey::Pubkey, rent::Rent,
 };
-use solana_program::msg;
-use solana_program::program_error::ProgramError;
-use solana_program::rent::Rent;
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
+
+use crate::{
+    error::DlpError::Unauthorized,
+    processor::utils::loaders::{
+        load_initialized_protocol_fees_vault, load_program_upgrade_authority,
+        load_signer,
+    },
+};
 
 /// Process request to claim fees from the protocol fees vault
 ///
@@ -38,7 +42,8 @@ pub fn process_protocol_claim_fees(
 
     // Check if the admin is the correct one
     let admin_pubkey =
-        load_program_upgrade_authority(&crate::ID, delegation_program_data)?.ok_or(Unauthorized)?;
+        load_program_upgrade_authority(&crate::ID, delegation_program_data)?
+            .ok_or(Unauthorized)?;
     if !admin.key.eq(&admin_pubkey) {
         msg!(
             "Expected admin pubkey: {} but got {}",
@@ -61,10 +66,11 @@ pub fn process_protocol_claim_fees(
         .checked_sub(amount)
         .ok_or(ProgramError::InsufficientFunds)?;
 
-    **admin.try_borrow_mut_lamports()? = admin
-        .lamports()
-        .checked_add(amount)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
+    **admin.try_borrow_mut_lamports()? =
+        admin
+            .lamports()
+            .checked_add(amount)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
 
     Ok(())
 }

--- a/src/processor/top_up_ephemeral_balance.rs
+++ b/src/processor/top_up_ephemeral_balance.rs
@@ -1,13 +1,17 @@
-use crate::args::TopUpEphemeralBalanceArgs;
-use crate::ephemeral_balance_seeds_from_payer;
-use crate::processor::utils::loaders::{load_pda, load_program, load_signer};
-use crate::processor::utils::pda::create_pda;
 use borsh::BorshDeserialize;
-use solana_program::program::invoke;
-use solana_program::program_error::ProgramError;
-use solana_program::system_instruction::transfer;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke,
+    program_error::ProgramError, pubkey::Pubkey, system_instruction::transfer,
+    system_program,
+};
+
+use crate::{
+    args::TopUpEphemeralBalanceArgs,
+    ephemeral_balance_seeds_from_payer,
+    processor::utils::{
+        loaders::{load_pda, load_program, load_signer},
+        pda::create_pda,
+    },
 };
 
 /// Tops up the ephemeral balance account.
@@ -36,7 +40,8 @@ pub fn process_top_up_ephemeral_balance(
     let args = TopUpEphemeralBalanceArgs::try_from_slice(data)?;
 
     // Load Accounts
-    let [payer, pubkey, ephemeral_balance_account, system_program] = accounts else {
+    let [payer, pubkey, ephemeral_balance_account, system_program] = accounts
+    else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -66,7 +71,8 @@ pub fn process_top_up_ephemeral_balance(
 
     // Transfer lamports from payer to ephemeral PDA (with a system program call)
     if args.amount > 0 {
-        let transfer_instruction = transfer(payer.key, ephemeral_balance_account.key, args.amount);
+        let transfer_instruction =
+            transfer(payer.key, ephemeral_balance_account.key, args.amount);
         invoke(
             &transfer_instruction,
             &[

--- a/src/processor/utils/curve.rs
+++ b/src/processor/utils/curve.rs
@@ -4,7 +4,9 @@ pub fn is_on_curve_fast(key: &pinocchio::Address) -> bool {
         use solana_curve25519::edwards::{validate_edwards, PodEdwardsPoint};
         // SAFETY: the layout of pinocchio::pubkey::Pubkey and PodEdwardsPoint is identical
         // so one can be casted to the other without any issue.
-        validate_edwards(unsafe { &*(key.as_array().as_ptr() as *const PodEdwardsPoint) })
+        validate_edwards(unsafe {
+            &*(key.as_array().as_ptr() as *const PodEdwardsPoint)
+        })
     }
 
     #[cfg(target_os = "solana")]

--- a/src/processor/utils/loaders.rs
+++ b/src/processor/utils/loaders.rs
@@ -1,15 +1,22 @@
-use crate::error::DlpError::InvalidAuthority;
-use crate::pda::validator_fees_vault_pda_from_validator;
-use crate::{fees_vault_seeds, validator_fees_vault_seeds_from_validator};
-use solana_program::bpf_loader_upgradeable::UpgradeableLoaderState;
 use solana_program::{
-    account_info::AccountInfo, bpf_loader_upgradeable, msg, program_error::ProgramError,
-    pubkey::Pubkey, system_program, sysvar,
+    account_info::AccountInfo, bpf_loader_upgradeable,
+    bpf_loader_upgradeable::UpgradeableLoaderState, msg,
+    program_error::ProgramError, pubkey::Pubkey, system_program, sysvar,
+};
+
+use crate::{
+    error::DlpError::InvalidAuthority, fees_vault_seeds,
+    pda::validator_fees_vault_pda_from_validator,
+    validator_fees_vault_seeds_from_validator,
 };
 
 /// Errors if:
 /// - Account is not owned by expected program.
-pub fn load_owned_pda(info: &AccountInfo, owner: &Pubkey, label: &str) -> Result<(), ProgramError> {
+pub fn load_owned_pda(
+    info: &AccountInfo,
+    owner: &Pubkey,
+    label: &str,
+) -> Result<(), ProgramError> {
     if !info.owner.eq(owner) {
         msg!("Invalid account owner for {} ({})", label, info.key);
         return Err(ProgramError::InvalidAccountOwner);
@@ -20,7 +27,10 @@ pub fn load_owned_pda(info: &AccountInfo, owner: &Pubkey, label: &str) -> Result
 
 /// Errors if:
 /// - Account is not a signer.
-pub fn load_signer(info: &AccountInfo, label: &str) -> Result<(), ProgramError> {
+pub fn load_signer(
+    info: &AccountInfo,
+    label: &str,
+) -> Result<(), ProgramError> {
     if !info.is_signer {
         msg!("Account needs to be signer {} ({})", label, info.key);
         return Err(ProgramError::MissingRequiredSignature);
@@ -139,7 +149,10 @@ pub fn load_uninitialized_account(
 /// - Owner is not the sysvar address.
 /// - Account cannot load with the expected address.
 #[allow(dead_code)]
-pub fn load_sysvar(info: &AccountInfo, key: Pubkey) -> Result<(), ProgramError> {
+pub fn load_sysvar(
+    info: &AccountInfo,
+    key: Pubkey,
+) -> Result<(), ProgramError> {
     if info.owner.ne(&sysvar::id()) {
         msg!("Invalid owner for sysvar: {}", info.key);
         return Err(ProgramError::InvalidAccountOwner);
@@ -173,7 +186,11 @@ pub fn load_account(
 /// Errors if:
 /// - Address does not match the expected value.
 /// - Account is not executable.
-pub fn load_program(info: &AccountInfo, key: Pubkey, label: &str) -> Result<(), ProgramError> {
+pub fn load_program(
+    info: &AccountInfo,
+    key: Pubkey,
+    label: &str,
+) -> Result<(), ProgramError> {
     if info.key.ne(&key) {
         msg!("Invalid program account: {} ({})", label, info.key);
         return Err(ProgramError::IncorrectProgramId);
@@ -192,8 +209,11 @@ pub fn load_program_upgrade_authority(
     program: &Pubkey,
     program_data: &AccountInfo,
 ) -> Result<Option<Pubkey>, ProgramError> {
-    let program_data_address =
-        Pubkey::find_program_address(&[program.as_ref()], &bpf_loader_upgradeable::id()).0;
+    let program_data_address = Pubkey::find_program_address(
+        &[program.as_ref()],
+        &bpf_loader_upgradeable::id(),
+    )
+    .0;
 
     // During tests, the upgrade authority is a test pubkey
     #[cfg(feature = "unit_test_config")]
@@ -270,13 +290,14 @@ pub fn load_initialized_validator_fees_vault(
 
 #[cfg(test)]
 mod tests {
-    use solana_program::{account_info::AccountInfo, pubkey::Pubkey, system_program};
-
-    use crate::processor::utils::loaders::{
-        load_account, load_signer, load_sysvar, load_uninitialized_account,
+    use solana_program::{
+        account_info::AccountInfo, pubkey::Pubkey, system_program,
     };
 
     use super::load_program;
+    use crate::processor::utils::loaders::{
+        load_account, load_signer, load_sysvar, load_uninitialized_account,
+    };
 
     #[test]
     pub fn test_signer_not_signer() {
@@ -332,7 +353,9 @@ mod tests {
             false,
             0,
         );
-        assert!(load_uninitialized_account(&info, true, "data not empty").is_err());
+        assert!(
+            load_uninitialized_account(&info, true, "data not empty").is_err()
+        );
     }
 
     #[test]
@@ -351,7 +374,9 @@ mod tests {
             false,
             0,
         );
-        assert!(load_uninitialized_account(&info, true, "not writeable").is_err());
+        assert!(
+            load_uninitialized_account(&info, true, "not writeable").is_err()
+        );
     }
 
     #[test]
@@ -370,7 +395,9 @@ mod tests {
             false,
             0,
         );
-        assert!(load_uninitialized_account(&info, false, "not writable").is_ok());
+        assert!(
+            load_uninitialized_account(&info, false, "not writable").is_ok()
+        );
     }
 
     #[test]
@@ -408,7 +435,8 @@ mod tests {
             false,
             0,
         );
-        assert!(load_account(&info, Pubkey::new_unique(), false, "bad key").is_err());
+        assert!(load_account(&info, Pubkey::new_unique(), false, "bad key")
+            .is_err());
     }
 
     #[test]

--- a/src/processor/utils/pda.rs
+++ b/src/processor/utils/pda.rs
@@ -1,7 +1,6 @@
-use solana_program::program::invoke;
-use solana_program::program_error::ProgramError;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, rent::Rent,
+    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke,
+    program_error::ProgramError, pubkey::Pubkey, rent::Rent,
     system_instruction, sysvar::Sysvar,
 };
 
@@ -60,7 +59,10 @@ pub(crate) fn create_pda<'a, 'info>(
         }
         // 2) allocate space for the account
         solana_program::program::invoke_signed(
-            &solana_program::system_instruction::allocate(target_account.key, space as u64),
+            &solana_program::system_instruction::allocate(
+                target_account.key,
+                space as u64,
+            ),
             &[
                 target_account.as_ref().clone(),
                 system_program.as_ref().clone(),
@@ -69,7 +71,10 @@ pub(crate) fn create_pda<'a, 'info>(
         )?;
         // 3) assign our program as the owner
         solana_program::program::invoke_signed(
-            &solana_program::system_instruction::assign(target_account.key, owner),
+            &solana_program::system_instruction::assign(
+                target_account.key,
+                owner,
+            ),
             &[
                 target_account.as_ref().clone(),
                 system_program.as_ref().clone(),

--- a/src/processor/validator_claim_fees.rs
+++ b/src/processor/validator_claim_fees.rs
@@ -1,14 +1,18 @@
-use crate::args::ValidatorClaimFeesArgs;
-use crate::consts::PROTOCOL_FEES_PERCENTAGE;
-use crate::error::DlpError;
-use crate::processor::utils::loaders::{
-    load_initialized_protocol_fees_vault, load_initialized_validator_fees_vault, load_signer,
-};
 use borsh::BorshDeserialize;
-use solana_program::msg;
-use solana_program::program_error::ProgramError;
-use solana_program::rent::Rent;
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program_error::ProgramError, pubkey::Pubkey, rent::Rent,
+};
+
+use crate::{
+    args::ValidatorClaimFeesArgs,
+    consts::PROTOCOL_FEES_PERCENTAGE,
+    error::DlpError,
+    processor::utils::loaders::{
+        load_initialized_protocol_fees_vault,
+        load_initialized_validator_fees_vault, load_signer,
+    },
+};
 
 /// Process validator request to claim fees from the fees vault
 ///
@@ -39,7 +43,11 @@ pub fn process_validator_claim_fees(
 
     load_signer(validator, "validator")?;
     load_initialized_protocol_fees_vault(fees_vault, true)?;
-    load_initialized_validator_fees_vault(validator, validator_fees_vault, true)?;
+    load_initialized_validator_fees_vault(
+        validator,
+        validator_fees_vault,
+        true,
+    )?;
 
     // Calculate the amount to transfer
     let min_rent = Rent::default().minimum_balance(8);

--- a/src/processor/whitelist_validator_for_program.rs
+++ b/src/processor/whitelist_validator_for_program.rs
@@ -1,16 +1,20 @@
-use crate::args::WhitelistValidatorForProgramArgs;
-use crate::error::DlpError::Unauthorized;
-use crate::processor::utils::loaders::{
-    load_pda, load_program, load_program_upgrade_authority, load_signer,
-};
-use crate::processor::utils::pda::{create_pda, resize_pda};
-use crate::program_config_seeds_from_program_id;
-use crate::state::ProgramConfig;
 use borsh::BorshDeserialize;
-use solana_program::msg;
-use solana_program::program_error::ProgramError;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg,
+    program_error::ProgramError, pubkey::Pubkey, system_program,
+};
+
+use crate::{
+    args::WhitelistValidatorForProgramArgs,
+    error::DlpError::Unauthorized,
+    processor::utils::{
+        loaders::{
+            load_pda, load_program, load_program_upgrade_authority, load_signer,
+        },
+        pda::{create_pda, resize_pda},
+    },
+    program_config_seeds_from_program_id,
+    state::ProgramConfig,
 };
 
 /// Whitelist a validator for a program
@@ -50,7 +54,12 @@ pub fn process_whitelist_validator_for_program(
     };
 
     load_signer(authority, "authority")?;
-    validate_authority(authority, program, program_data, delegation_program_data)?;
+    validate_authority(
+        authority,
+        program,
+        program_data,
+        delegation_program_data,
+    )?;
     load_program(system_program, system_program::id(), "system program")?;
 
     let program_config_bump = load_pda(
@@ -62,7 +71,10 @@ pub fn process_whitelist_validator_for_program(
     )?;
 
     // Get the program config. If the account doesn't exist, create it
-    let mut program_config = if program_config_account.owner.eq(system_program.key) {
+    let mut program_config = if program_config_account
+        .owner
+        .eq(system_program.key)
+    {
         create_pda(
             program_config_account,
             &crate::id(),
@@ -92,8 +104,10 @@ pub fn process_whitelist_validator_for_program(
         system_program,
         program_config.size_with_discriminator(),
     )?;
-    let mut program_config_data = program_config_account.try_borrow_mut_data()?;
-    program_config.to_bytes_with_discriminator(&mut program_config_data.as_mut())?;
+    let mut program_config_data =
+        program_config_account.try_borrow_mut_data()?;
+    program_config
+        .to_bytes_with_discriminator(&mut program_config_data.as_mut())?;
 
     Ok(())
 }
@@ -106,11 +120,14 @@ fn validate_authority(
     delegation_program_data: &AccountInfo,
 ) -> Result<(), ProgramError> {
     let admin_pubkey =
-        load_program_upgrade_authority(&crate::ID, delegation_program_data)?.ok_or(Unauthorized)?;
+        load_program_upgrade_authority(&crate::ID, delegation_program_data)?
+            .ok_or(Unauthorized)?;
     if authority.key.eq(&admin_pubkey)
-        || authority
-            .key
-            .eq(&load_program_upgrade_authority(program.key, program_data)?.ok_or(Unauthorized)?)
+        || authority.key.eq(&load_program_upgrade_authority(
+            program.key,
+            program_data,
+        )?
+        .ok_or(Unauthorized)?)
     {
         Ok(())
     } else {

--- a/src/state/commit_record.rs
+++ b/src/state/commit_record.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use bytemuck::{Pod, Zeroable};
 use solana_program::pubkey::Pubkey;
 
-use crate::{
-    impl_to_bytes_with_discriminator_zero_copy, impl_try_from_bytes_with_discriminator_zero_copy,
-};
-
 use super::discriminator::{AccountDiscriminator, AccountWithDiscriminator};
+use crate::{
+    impl_to_bytes_with_discriminator_zero_copy,
+    impl_try_from_bytes_with_discriminator_zero_copy,
+};
 
 /// The Commit State Record
 #[repr(C)]

--- a/src/state/delegation_metadata.rs
+++ b/src/state/delegation_metadata.rs
@@ -1,14 +1,14 @@
 use std::ptr;
 
-use crate::{
-    impl_to_bytes_with_discriminator_borsh, impl_try_from_bytes_with_discriminator_borsh,
-    require_ge,
-};
 use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::{account::RefMut, error::ProgramError, AccountView};
 use solana_program::pubkey::Pubkey;
 
 use super::discriminator::{AccountDiscriminator, AccountWithDiscriminator};
+use crate::{
+    impl_to_bytes_with_discriminator_borsh,
+    impl_try_from_bytes_with_discriminator_borsh, require_ge,
+};
 
 /// The Delegated Metadata includes Account Seeds, max delegation time, seeds
 /// and other meta information about the delegated account.
@@ -31,7 +31,9 @@ pub struct DelegationMetadataFast<'a> {
 }
 
 impl<'a> DelegationMetadataFast<'a> {
-    pub fn from_account(account: &'a AccountView) -> Result<Self, ProgramError> {
+    pub fn from_account(
+        account: &'a AccountView,
+    ) -> Result<Self, ProgramError> {
         require_ge!(
             account.data_len(),
             AccountDiscriminator::SPACE
@@ -48,13 +50,17 @@ impl<'a> DelegationMetadataFast<'a> {
     }
 
     pub fn last_update_nonce(&self) -> u64 {
-        unsafe { ptr::read(self.data.as_ptr().add(AccountDiscriminator::SPACE) as *const u64) }
+        unsafe {
+            ptr::read(self.data.as_ptr().add(AccountDiscriminator::SPACE)
+                as *const u64)
+        }
     }
 
     pub fn set_last_update_nonce(&mut self, val: u64) {
         unsafe {
             ptr::write(
-                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE) as *mut u64,
+                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE)
+                    as *mut u64,
                 val,
             )
         }
@@ -63,7 +69,8 @@ impl<'a> DelegationMetadataFast<'a> {
     pub fn replace_last_update_nonce(&mut self, val: u64) -> u64 {
         unsafe {
             ptr::replace(
-                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE) as *mut u64,
+                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE)
+                    as *mut u64,
                 val,
             )
         }
@@ -72,7 +79,8 @@ impl<'a> DelegationMetadataFast<'a> {
     pub fn set_is_undelegatable(&mut self, val: bool) {
         unsafe {
             ptr::write(
-                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE + 8) as *mut bool,
+                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE + 8)
+                    as *mut bool,
                 val,
             )
         }
@@ -81,7 +89,8 @@ impl<'a> DelegationMetadataFast<'a> {
     pub fn replace_is_undelegatable(&mut self, val: bool) -> bool {
         unsafe {
             ptr::replace(
-                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE + 8) as *mut bool,
+                self.data.as_mut_ptr().add(AccountDiscriminator::SPACE + 8)
+                    as *mut bool,
                 val,
             )
         }
@@ -119,8 +128,9 @@ mod tests {
             seeds: vec![
                 vec![],
                 vec![
-                    215, 233, 74, 188, 162, 203, 12, 212, 106, 87, 189, 226, 48, 38, 129, 7, 34,
-                    82, 254, 106, 161, 35, 74, 146, 30, 211, 164, 97, 139, 136, 136, 77,
+                    215, 233, 74, 188, 162, 203, 12, 212, 106, 87, 189, 226,
+                    48, 38, 129, 7, 34, 82, 254, 106, 161, 35, 74, 146, 30,
+                    211, 164, 97, 139, 136, 136, 77,
                 ],
             ],
             is_undelegatable: false,
@@ -133,7 +143,8 @@ mod tests {
 
         // Deserialize
         let deserialized: DelegationMetadata =
-            DelegationMetadata::try_from_slice(&serialized).expect("Deserialization failed");
+            DelegationMetadata::try_from_slice(&serialized)
+                .expect("Deserialization failed");
 
         assert_eq!(deserialized, original);
     }

--- a/src/state/delegation_record.rs
+++ b/src/state/delegation_record.rs
@@ -1,12 +1,13 @@
 use std::mem::size_of;
 
-use crate::impl_to_bytes_with_discriminator_zero_copy;
-use crate::impl_try_from_bytes_with_discriminator_zero_copy;
 use bytemuck::{Pod, Zeroable};
 use solana_program::pubkey::Pubkey;
 
-use super::discriminator::AccountDiscriminator;
-use super::discriminator::AccountWithDiscriminator;
+use super::discriminator::{AccountDiscriminator, AccountWithDiscriminator};
+use crate::{
+    impl_to_bytes_with_discriminator_zero_copy,
+    impl_try_from_bytes_with_discriminator_zero_copy,
+};
 
 /// The Delegation Record stores information such as the authority, the owner and the commit frequency.
 /// This is used by the ephemeral validator to update the state of the delegated account.

--- a/src/state/program_config.rs
+++ b/src/state/program_config.rs
@@ -1,10 +1,13 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::pubkey::Pubkey;
 use std::collections::BTreeSet;
 
-use crate::{impl_to_bytes_with_discriminator_borsh, impl_try_from_bytes_with_discriminator_borsh};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
 
 use super::discriminator::{AccountDiscriminator, AccountWithDiscriminator};
+use crate::{
+    impl_to_bytes_with_discriminator_borsh,
+    impl_try_from_bytes_with_discriminator_borsh,
+};
 
 #[derive(BorshSerialize, BorshDeserialize, Default, Debug)]
 pub struct ProgramConfig {

--- a/src/state/utils/discriminator.rs
+++ b/src/state/utils/discriminator.rs
@@ -1,7 +1,9 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive,
+)]
 pub enum AccountDiscriminator {
     DelegationRecord = 100,
     DelegationMetadata = 102,

--- a/src/state/utils/to_bytes.rs
+++ b/src/state/utils/to_bytes.rs
@@ -8,7 +8,9 @@ macro_rules! impl_to_bytes_with_discriminator_zero_copy {
             ) -> Result<(), ::solana_program::program_error::ProgramError> {
                 let expected_len = 8 + ::std::mem::size_of::<Self>();
                 if data.len() != expected_len {
-                    return Err($crate::error::DlpError::InvalidDataLength.into());
+                    return Err(
+                        $crate::error::DlpError::InvalidDataLength.into()
+                    );
                 }
                 data[..8].copy_from_slice(&Self::discriminator().to_bytes());
                 data[8..].copy_from_slice(bytemuck::bytes_of(self));

--- a/src/state/utils/try_from_bytes.rs
+++ b/src/state/utils/try_from_bytes.rs
@@ -38,12 +38,17 @@ macro_rules! impl_try_from_bytes_with_discriminator_borsh {
         impl $struct_name {
             pub fn try_from_bytes_with_discriminator(
                 data: &[u8],
-            ) -> Result<Self, ::solana_program::program_error::ProgramError> {
+            ) -> Result<Self, ::solana_program::program_error::ProgramError>
+            {
                 if data.len() < 8 {
-                    return Err($crate::error::DlpError::InvalidDataLength.into());
+                    return Err(
+                        $crate::error::DlpError::InvalidDataLength.into()
+                    );
                 }
                 if Self::discriminator().to_bytes().ne(&data[..8]) {
-                    return Err($crate::error::DlpError::InvalidDiscriminator.into());
+                    return Err(
+                        $crate::error::DlpError::InvalidDiscriminator.into()
+                    );
                 }
                 Self::try_from_slice(&data[8..]).or(Err(
                     $crate::error::DlpError::InvalidDelegationRecordData.into(),

--- a/tests/fixtures/accounts.rs
+++ b/tests/fixtures/accounts.rs
@@ -1,8 +1,9 @@
-use dlp::state::{CommitRecord, DelegationMetadata, DelegationRecord, ProgramConfig};
-use solana_program::native_token::LAMPORTS_PER_SOL;
-use solana_program::pubkey::Pubkey;
-use solana_program::rent::Rent;
-use solana_program::system_program;
+use dlp::state::{
+    CommitRecord, DelegationMetadata, DelegationRecord, ProgramConfig,
+};
+use solana_program::{
+    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, rent::Rent, system_program,
+};
 use solana_sdk::pubkey;
 
 // Constants for default values
@@ -13,22 +14,28 @@ const DEFAULT_IS_UNDELEGATABLE: bool = false;
 const DEFAULT_SEEDS: &[&[u8]] = &[&[116, 101, 115, 116, 45, 112, 100, 97]];
 
 #[allow(dead_code)]
-pub const COMMIT_STATE_AUTHORITY: Pubkey = pubkey!("Ec6jL2GVTzjfHz8RFP3mVyki9JRNmMu8E7YdNh45xNdk");
+pub const COMMIT_STATE_AUTHORITY: Pubkey =
+    pubkey!("Ec6jL2GVTzjfHz8RFP3mVyki9JRNmMu8E7YdNh45xNdk");
 
 #[allow(dead_code)]
-pub const COMMIT_NEW_STATE_ACCOUNT_DATA: [u8; 11] = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 11];
+pub const COMMIT_NEW_STATE_ACCOUNT_DATA: [u8; 11] =
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 11];
 
 #[allow(dead_code)]
-pub const DELEGATED_PDA_ID: Pubkey = pubkey!("8k2V7EzQtNg38Gi9HK5ZtQYp1YpGKNGrMcuGa737gZX4");
+pub const DELEGATED_PDA_ID: Pubkey =
+    pubkey!("8k2V7EzQtNg38Gi9HK5ZtQYp1YpGKNGrMcuGa737gZX4");
 
 #[allow(dead_code)]
-pub const DELEGATED_PDA: [u8; 19] = [15, 0, 0, 0, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
+pub const DELEGATED_PDA: [u8; 19] =
+    [15, 0, 0, 0, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
 
 #[allow(dead_code)]
-pub const DELEGATED_PDA_OWNER_ID: Pubkey = pubkey!("3vAK9JQiDsKoQNwmcfeEng4Cnv22pYuj1ASfso7U4ukF");
+pub const DELEGATED_PDA_OWNER_ID: Pubkey =
+    pubkey!("3vAK9JQiDsKoQNwmcfeEng4Cnv22pYuj1ASfso7U4ukF");
 
 #[allow(dead_code)]
-pub const EXTERNAL_DELEGATE_INSTRUCTION_DISCRIMINATOR: [u8; 8] = [90, 147, 75, 178, 85, 88, 4, 137];
+pub const EXTERNAL_DELEGATE_INSTRUCTION_DISCRIMINATOR: [u8; 8] =
+    [90, 147, 75, 178, 85, 88, 4, 137];
 
 #[allow(dead_code)]
 pub const EXTERNAL_ALLOW_UNDELEGATION_INSTRUCTION_DISCRIMINATOR: [u8; 8] =
@@ -36,23 +43,30 @@ pub const EXTERNAL_ALLOW_UNDELEGATION_INSTRUCTION_DISCRIMINATOR: [u8; 8] =
 
 #[allow(dead_code)]
 pub const ON_CURVE_KEYPAIR: [u8; 64] = [
-    74, 198, 48, 104, 119, 57, 255, 80, 67, 181, 191, 189, 85, 21, 235, 45, 185, 175, 48, 143, 13,
-    202, 92, 81, 211, 108, 61, 237, 183, 116, 207, 45, 170, 118, 238, 247, 128, 91, 3, 41, 33, 10,
-    241, 163, 185, 198, 228, 172, 200, 220, 225, 192, 149, 94, 106, 209, 65, 79, 210, 54, 191, 49,
-    115, 159,
+    74, 198, 48, 104, 119, 57, 255, 80, 67, 181, 191, 189, 85, 21, 235, 45,
+    185, 175, 48, 143, 13, 202, 92, 81, 211, 108, 61, 237, 183, 116, 207, 45,
+    170, 118, 238, 247, 128, 91, 3, 41, 33, 10, 241, 163, 185, 198, 228, 172,
+    200, 220, 225, 192, 149, 94, 106, 209, 65, 79, 210, 54, 191, 49, 115, 159,
 ];
 
 #[allow(dead_code)]
 pub const TEST_AUTHORITY: [u8; 64] = [
-    251, 62, 129, 184, 107, 49, 62, 184, 1, 147, 178, 128, 185, 157, 247, 92, 56, 158, 145, 53, 51,
-    226, 202, 96, 178, 248, 195, 133, 133, 237, 237, 146, 13, 32, 77, 204, 244, 56, 166, 172, 66,
-    113, 150, 218, 112, 42, 110, 181, 98, 158, 222, 194, 130, 93, 175, 100, 190, 106, 9, 69, 156,
-    80, 96, 72,
+    251, 62, 129, 184, 107, 49, 62, 184, 1, 147, 178, 128, 185, 157, 247, 92,
+    56, 158, 145, 53, 51, 226, 202, 96, 178, 248, 195, 133, 133, 237, 237, 146,
+    13, 32, 77, 204, 244, 56, 166, 172, 66, 113, 150, 218, 112, 42, 110, 181,
+    98, 158, 222, 194, 130, 93, 175, 100, 190, 106, 9, 69, 156, 80, 96, 72,
 ];
 
 #[allow(dead_code)]
-pub fn get_delegation_record_data(authority: Pubkey, last_update_lamports: Option<u64>) -> Vec<u8> {
-    create_delegation_record_data(authority, DELEGATED_PDA_OWNER_ID, last_update_lamports)
+pub fn get_delegation_record_data(
+    authority: Pubkey,
+    last_update_lamports: Option<u64>,
+) -> Vec<u8> {
+    create_delegation_record_data(
+        authority,
+        DELEGATED_PDA_OWNER_ID,
+        last_update_lamports,
+    )
 }
 
 #[allow(dead_code)]
@@ -60,7 +74,11 @@ pub fn get_delegation_record_on_curve_data(
     authority: Pubkey,
     last_update_lamports: Option<u64>,
 ) -> Vec<u8> {
-    create_delegation_record_data(authority, system_program::id(), last_update_lamports)
+    create_delegation_record_data(
+        authority,
+        system_program::id(),
+        last_update_lamports,
+    )
 }
 
 #[allow(dead_code)]
@@ -74,7 +92,8 @@ pub fn create_delegation_record_data(
         owner,
         delegation_slot: DEFAULT_DELEGATION_SLOT,
         commit_frequency_ms: DEFAULT_COMMIT_FREQUENCY_MS,
-        lamports: last_update_lamports.unwrap_or(Rent::default().minimum_balance(500)),
+        lamports: last_update_lamports
+            .unwrap_or(Rent::default().minimum_balance(500)),
     };
     let mut bytes = vec![0u8; DelegationRecord::size_with_discriminator()];
     delegation_record
@@ -96,7 +115,10 @@ pub fn get_delegation_metadata_data_on_curve(
 }
 
 #[allow(dead_code)]
-pub fn get_delegation_metadata_data(rent_payer: Pubkey, is_undelegatable: Option<bool>) -> Vec<u8> {
+pub fn get_delegation_metadata_data(
+    rent_payer: Pubkey,
+    is_undelegatable: Option<bool>,
+) -> Vec<u8> {
     create_delegation_metadata_data(
         rent_payer,
         DEFAULT_SEEDS,

--- a/tests/test_call_handler.rs
+++ b/tests/test_call_handler.rs
@@ -1,25 +1,33 @@
-use crate::fixtures::{
-    create_delegation_metadata_data, create_delegation_record_data, get_commit_record_account_data,
-    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
-};
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
-use dlp::args::CallHandlerArgs;
-use dlp::ephemeral_balance_seeds_from_payer;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    ephemeral_balance_pda_from_payer, fees_vault_pda, validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CallHandlerArgs,
+    ephemeral_balance_seeds_from_payer,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        ephemeral_balance_pda_from_payer, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
 };
-use solana_program::instruction::AccountMeta;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, instruction::AccountMeta, native_token::LAMPORTS_PER_SOL,
+    rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::{
     account::Account,
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
+};
+
+use crate::fixtures::{
+    create_delegation_metadata_data, create_delegation_record_data,
+    get_commit_record_account_data, get_delegation_metadata_data,
+    get_delegation_record_data, DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID,
+    TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -33,7 +41,10 @@ pub struct Counter {
     pub count: u64,
 }
 
-async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
+async fn setup_delegated_pda(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
     let state = to_vec(&Counter { count: 100 }).unwrap();
     // Setup a delegated PDA
     program_test.add_account(
@@ -48,11 +59,13 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 
     // Setup the delegation record PDA
-    let delegation_record_data = get_delegation_record_data(*authority_pubkey, None);
+    let delegation_record_data =
+        get_delegation_record_data(*authority_pubkey, None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data.clone(),
             owner: dlp::id(),
             executable: false,
@@ -61,11 +74,13 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(*authority_pubkey, Some(true));
+    let delegation_metadata_data =
+        get_delegation_metadata_data(*authority_pubkey, Some(true));
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -74,7 +89,10 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 }
 
-async fn setup_commit_state(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
+async fn setup_commit_state(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
     // Setup the commit state PDA
     let commit_state = to_vec(&Counter { count: 101 }).unwrap();
     program_test.add_account(
@@ -101,8 +119,12 @@ async fn setup_commit_state(program_test: &mut ProgramTest, authority_pubkey: &P
     );
 }
 
-async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&DELEGATED_PDA_ID, 0);
+async fn setup_invalid_escrow_account(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&DELEGATED_PDA_ID, 0);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -117,12 +139,16 @@ async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data =
-        create_delegation_record_data(*authority_pubkey, dlp::id(), Some(LAMPORTS_PER_SOL));
+    let delegation_record_data = create_delegation_record_data(
+        *authority_pubkey,
+        dlp::id(),
+        Some(LAMPORTS_PER_SOL),
+    );
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -139,7 +165,8 @@ async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -153,7 +180,8 @@ async fn setup_delegated_ephemeral_balance(
     validator: &Keypair,
     payer: &Keypair,
 ) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 1);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 1);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -176,7 +204,8 @@ async fn setup_delegated_ephemeral_balance(
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -193,7 +222,8 @@ async fn setup_delegated_ephemeral_balance(
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -202,8 +232,12 @@ async fn setup_delegated_ephemeral_balance(
     );
 }
 
-async fn setup_ephemeral_balance(program_test: &mut ProgramTest, payer: &Keypair) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 2);
+async fn setup_ephemeral_balance(
+    program_test: &mut ProgramTest,
+    payer: &Keypair,
+) {
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 2);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -241,7 +275,8 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     setup_delegated_pda(&mut program_test, &validator.pubkey()).await;
     setup_commit_state(&mut program_test, &validator.pubkey()).await;
     setup_invalid_escrow_account(&mut program_test, &validator.pubkey()).await;
-    setup_delegated_ephemeral_balance(&mut program_test, &validator, &payer).await;
+    setup_delegated_ephemeral_balance(&mut program_test, &validator, &payer)
+        .await;
     setup_ephemeral_balance(&mut program_test, &payer).await;
 
     // Setup the protocol fees vault
@@ -292,7 +327,10 @@ async fn test_finalize_call_handler() {
     let (banks, payer, validator, blockhash) = setup_program_test_env().await;
 
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(validator.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        validator.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let call_handler_ix = dlp::instruction_builder::call_handler(
         validator.pubkey(),
         DELEGATED_PDA_OWNER_ID, // destination program
@@ -337,7 +375,10 @@ async fn test_undelegate_call_handler() {
     let (banks, payer, validator, blockhash) = setup_program_test_env().await;
 
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(validator.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        validator.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let undelegate_ix = dlp::instruction_builder::undelegate(
         validator.pubkey(),
         DELEGATED_PDA_ID,
@@ -370,7 +411,8 @@ async fn test_undelegate_call_handler() {
         blockhash,
     );
 
-    let counter_before = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let counter_before =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     println!("counter before: {:?}", counter_before.data);
     let counter_before = Counter::try_from_slice(&counter_before.data).unwrap();
     println!("counter before: {}", counter_before.count);
@@ -385,7 +427,8 @@ async fn test_undelegate_call_handler() {
         .unwrap();
     assert_eq!(transfer_destination.lamports, PRIZE);
 
-    let counter_after = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let counter_after =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     let counter_after = Counter::try_from_slice(&counter_after.data).unwrap();
     // Committing state from count 100 to 101, and then increasing in handler on 1
     assert_eq!(counter_before.count + 2, counter_after.count);
@@ -399,7 +442,10 @@ async fn test_finalize_invalid_escrow_call_handler() {
 
     // Submit the finalize with handler tx
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let call_handler_ix = dlp::instruction_builder::call_handler(
         authority.pubkey(),
         DELEGATED_PDA_OWNER_ID, // destination program
@@ -431,7 +477,10 @@ async fn test_undelegate_invalid_escow_call_handler() {
 
     // Submit the finalize with handler tx
     let destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let finalize_call_handler_ix = dlp::instruction_builder::call_handler(
         authority.pubkey(),
         DELEGATED_PDA_OWNER_ID, // handler program

--- a/tests/test_call_handler_v2.rs
+++ b/tests/test_call_handler_v2.rs
@@ -1,25 +1,33 @@
-use crate::fixtures::{
-    create_delegation_metadata_data, create_delegation_record_data, get_commit_record_account_data,
-    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
-};
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
-use dlp::args::CallHandlerArgs;
-use dlp::ephemeral_balance_seeds_from_payer;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    ephemeral_balance_pda_from_payer, fees_vault_pda, validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CallHandlerArgs,
+    ephemeral_balance_seeds_from_payer,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        ephemeral_balance_pda_from_payer, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
 };
-use solana_program::instruction::AccountMeta;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, instruction::AccountMeta, native_token::LAMPORTS_PER_SOL,
+    rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::{
     account::Account,
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
+};
+
+use crate::fixtures::{
+    create_delegation_metadata_data, create_delegation_record_data,
+    get_commit_record_account_data, get_delegation_metadata_data,
+    get_delegation_record_data, DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID,
+    TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -33,7 +41,10 @@ pub struct Counter {
     pub count: u64,
 }
 
-async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
+async fn setup_delegated_pda(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
     let state = to_vec(&Counter { count: 100 }).unwrap();
     // Setup a delegated PDA
     program_test.add_account(
@@ -48,11 +59,13 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 
     // Setup the delegation record PDA
-    let delegation_record_data = get_delegation_record_data(*authority_pubkey, None);
+    let delegation_record_data =
+        get_delegation_record_data(*authority_pubkey, None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data.clone(),
             owner: dlp::id(),
             executable: false,
@@ -61,11 +74,13 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(*authority_pubkey, Some(true));
+    let delegation_metadata_data =
+        get_delegation_metadata_data(*authority_pubkey, Some(true));
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -74,7 +89,10 @@ async fn setup_delegated_pda(program_test: &mut ProgramTest, authority_pubkey: &
     );
 }
 
-async fn setup_commit_state(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
+async fn setup_commit_state(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
     // Setup the commit state PDA
     let commit_state = to_vec(&Counter { count: 101 }).unwrap();
     program_test.add_account(
@@ -101,8 +119,12 @@ async fn setup_commit_state(program_test: &mut ProgramTest, authority_pubkey: &P
     );
 }
 
-async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_pubkey: &Pubkey) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&DELEGATED_PDA_ID, 0);
+async fn setup_invalid_escrow_account(
+    program_test: &mut ProgramTest,
+    authority_pubkey: &Pubkey,
+) {
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&DELEGATED_PDA_ID, 0);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -117,12 +139,16 @@ async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data =
-        create_delegation_record_data(*authority_pubkey, dlp::id(), Some(LAMPORTS_PER_SOL));
+    let delegation_record_data = create_delegation_record_data(
+        *authority_pubkey,
+        dlp::id(),
+        Some(LAMPORTS_PER_SOL),
+    );
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -139,7 +165,8 @@ async fn setup_invalid_escrow_account(program_test: &mut ProgramTest, authority_
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -153,7 +180,8 @@ async fn setup_delegated_ephemeral_balance(
     validator: &Keypair,
     payer: &Keypair,
 ) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 1);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 1);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -176,7 +204,8 @@ async fn setup_delegated_ephemeral_balance(
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -193,7 +222,8 @@ async fn setup_delegated_ephemeral_balance(
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -202,8 +232,12 @@ async fn setup_delegated_ephemeral_balance(
     );
 }
 
-async fn setup_ephemeral_balance(program_test: &mut ProgramTest, payer: &Keypair) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 2);
+async fn setup_ephemeral_balance(
+    program_test: &mut ProgramTest,
+    payer: &Keypair,
+) {
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 2);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -241,7 +275,8 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     setup_delegated_pda(&mut program_test, &validator.pubkey()).await;
     setup_commit_state(&mut program_test, &validator.pubkey()).await;
     setup_invalid_escrow_account(&mut program_test, &validator.pubkey()).await;
-    setup_delegated_ephemeral_balance(&mut program_test, &validator, &payer).await;
+    setup_delegated_ephemeral_balance(&mut program_test, &validator, &payer)
+        .await;
     setup_ephemeral_balance(&mut program_test, &payer).await;
 
     // Setup the protocol fees vault
@@ -292,7 +327,10 @@ async fn test_finalize_call_handler_v2() {
     let (banks, payer, validator, blockhash) = setup_program_test_env().await;
 
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(validator.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        validator.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let call_handler_v2_ix = dlp::instruction_builder::call_handler_v2(
         validator.pubkey(),
         DELEGATED_PDA_OWNER_ID, // destination program
@@ -338,7 +376,10 @@ async fn test_undelegate_call_handler_v2() {
     let (banks, payer, validator, blockhash) = setup_program_test_env().await;
 
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(validator.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        validator.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let undelegate_ix = dlp::instruction_builder::undelegate(
         validator.pubkey(),
         DELEGATED_PDA_ID,
@@ -372,7 +413,8 @@ async fn test_undelegate_call_handler_v2() {
         blockhash,
     );
 
-    let counter_before = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let counter_before =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     let counter_before = Counter::try_from_slice(&counter_before.data).unwrap();
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
@@ -385,7 +427,8 @@ async fn test_undelegate_call_handler_v2() {
         .unwrap();
     assert_eq!(transfer_destination.lamports, PRIZE);
 
-    let counter_after = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let counter_after =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     let counter_after = Counter::try_from_slice(&counter_after.data).unwrap();
     // Committing state from count 100 to 101, and then increasing in handler on 1
     assert_eq!(counter_before.count + 2, counter_after.count);
@@ -399,7 +442,10 @@ async fn test_finalize_invalid_escrow_call_handler_v2() {
 
     // Submit the finalize with handler tx
     let transfer_destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let call_handler_v2_ix = dlp::instruction_builder::call_handler_v2(
         authority.pubkey(),
         DELEGATED_PDA_OWNER_ID, // destination program
@@ -432,7 +478,10 @@ async fn test_undelegate_invalid_escrow_call_handler_v2() {
 
     // Submit the finalize with handler tx
     let destination = Keypair::new();
-    let finalize_ix = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let finalize_ix = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let finalize_call_handler_v2_ix = dlp::instruction_builder::call_handler_v2(
         authority.pubkey(),
         DELEGATED_PDA_OWNER_ID, // handler program
@@ -451,21 +500,22 @@ async fn test_undelegate_invalid_escrow_call_handler_v2() {
         DELEGATED_PDA_OWNER_ID,
         authority.pubkey(),
     );
-    let undelegate_call_handler_v2_ix = dlp::instruction_builder::call_handler_v2(
-        authority.pubkey(),
-        DELEGATED_PDA_OWNER_ID, // handler program
-        DELEGATED_PDA_OWNER_ID, // source program
-        DELEGATED_PDA_ID,
-        vec![AccountMeta::new(destination.pubkey(), false)],
-        CallHandlerArgs {
-            escrow_index: 0,
-            data: [
-                UNDELEGATE_HANDLER_V2_DISCRIMINATOR.to_vec(),
-                to_vec(&PRIZE).unwrap(),
-            ]
-            .concat(),
-        },
-    );
+    let undelegate_call_handler_v2_ix =
+        dlp::instruction_builder::call_handler_v2(
+            authority.pubkey(),
+            DELEGATED_PDA_OWNER_ID, // handler program
+            DELEGATED_PDA_OWNER_ID, // source program
+            DELEGATED_PDA_ID,
+            vec![AccountMeta::new(destination.pubkey(), false)],
+            CallHandlerArgs {
+                escrow_index: 0,
+                data: [
+                    UNDELEGATE_HANDLER_V2_DISCRIMINATOR.to_vec(),
+                    to_vec(&PRIZE).unwrap(),
+                ]
+                .concat(),
+            },
+        );
     let tx = Transaction::new_signed_with_payer(
         &[
             finalize_ix,

--- a/tests/test_close_validator_fees_vault.rs
+++ b/tests/test_close_validator_fees_vault.rs
@@ -1,12 +1,15 @@
-use crate::fixtures::TEST_AUTHORITY;
 use dlp::pda::validator_fees_vault_pda_from_validator;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+
+use crate::fixtures::TEST_AUTHORITY;
 
 mod fixtures;
 
@@ -15,7 +18,8 @@ async fn test_close_validator_fees_vault() {
     // Setup
     let (banks, admin, validator, blockhash) = setup_program_test_env().await;
 
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator.pubkey());
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator.pubkey());
 
     // Submit the close vault tx
     let ix = dlp::instruction_builder::close_validator_fees_vault(
@@ -23,12 +27,18 @@ async fn test_close_validator_fees_vault() {
         admin.pubkey(),
         validator.pubkey(),
     );
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin.pubkey()), &[&admin], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&admin.pubkey()),
+        &[&admin],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 
     // Assert the validator fees vault now has been closed
-    let validator_fees_vault_account = banks.get_account(validator_fees_vault_pda).await.unwrap();
+    let validator_fees_vault_account =
+        banks.get_account(validator_fees_vault_pda).await.unwrap();
     assert!(validator_fees_vault_account.is_none());
 }
 

--- a/tests/test_commit_fees_on_undelegation.rs
+++ b/tests/test_commit_fees_on_undelegation.rs
@@ -1,10 +1,14 @@
-use dlp::consts::{COMMIT_FEE_LAMPORTS, SESSION_FEE_LAMPORTS};
-use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, validator_fees_vault_pda_from_validator,
+use dlp::{
+    consts::{COMMIT_FEE_LAMPORTS, SESSION_FEE_LAMPORTS},
+    pda::{
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -13,8 +17,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    create_delegation_metadata_data_with_nonce, get_delegation_record_data, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
+    create_delegation_metadata_data_with_nonce, get_delegation_record_data,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -31,14 +35,22 @@ async fn test_commit_fees_on_undelegation() {
         .unwrap()
         .lamports;
 
-    let delegation_record_data = get_delegation_record_data(validator.pubkey(), None);
-    let delegation_metadata_data =
-        create_delegation_metadata_data_with_nonce(validator.pubkey(), &[], true, 101);
+    let delegation_record_data =
+        get_delegation_record_data(validator.pubkey(), None);
+    let delegation_metadata_data = create_delegation_metadata_data_with_nonce(
+        validator.pubkey(),
+        &[],
+        true,
+        101,
+    );
 
-    let record_rent = Rent::default().minimum_balance(delegation_record_data.len());
-    let metadata_rent = Rent::default().minimum_balance(delegation_metadata_data.len());
-    let expected_total_fees =
-        (COMMIT_FEE_LAMPORTS * 100 + SESSION_FEE_LAMPORTS).min(record_rent + metadata_rent);
+    let record_rent =
+        Rent::default().minimum_balance(delegation_record_data.len());
+    let metadata_rent =
+        Rent::default().minimum_balance(delegation_metadata_data.len());
+    let expected_total_fees = (COMMIT_FEE_LAMPORTS * 100
+        + SESSION_FEE_LAMPORTS)
+        .min(record_rent + metadata_rent);
     let expected_fees_vault_fee = expected_total_fees / 10;
 
     let ix = dlp::instruction_builder::undelegate(
@@ -97,11 +109,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -110,12 +124,17 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated account metadata PDA with high nonce
-    let delegation_metadata_data =
-        create_delegation_metadata_data_with_nonce(validator.pubkey(), &[], true, 101);
+    let delegation_metadata_data = create_delegation_metadata_data_with_nonce(
+        validator.pubkey(),
+        &[],
+        true,
+        101,
+    );
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_commit_finalize.rs
+++ b/tests/test_commit_finalize.rs
@@ -1,13 +1,19 @@
-use dlp::args::CommitFinalizeArgs;
-use dlp::compute_diff;
-use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitFinalizeArgs,
+    compute_diff,
+    pda::{
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::DelegationMetadata,
 };
-use dlp::state::DelegationMetadata;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
-use solana_program_test::{BanksClient, BanksTransactionResultWithMetadata, ProgramTest};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
+use solana_program_test::{
+    BanksClient, BanksTransactionResultWithMetadata, ProgramTest,
+};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
@@ -15,7 +21,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID, TEST_AUTHORITY,
+    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
+    TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -37,7 +44,8 @@ async fn run_test_commit_finalize(
     max_expected_cu: u64,
 ) {
     // Setup
-    let (banks, _, authority, blockhash) = setup_program_test_env(old_state.clone()).await;
+    let (banks, _, authority, blockhash) =
+        setup_program_test_env(old_state.clone()).await;
 
     let new_account_balance = 1_000_000;
 
@@ -74,7 +82,10 @@ async fn run_test_commit_finalize(
 
         let metadata = metadata.unwrap();
 
-        assertables::assert_lt!(metadata.compute_units_consumed, max_expected_cu);
+        assertables::assert_lt!(
+            metadata.compute_units_consumed,
+            max_expected_cu
+        );
 
         assert_eq!(
             metadata.log_messages.len(),
@@ -83,7 +94,8 @@ async fn run_test_commit_finalize(
         );
     }
 
-    let delegated_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert_eq!(delegated_account.data, new_state);
 
     let delegation_metadata_account = banks
@@ -93,8 +105,10 @@ async fn run_test_commit_finalize(
         .unwrap();
 
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
 
     assert_eq!(delegation_metadata.is_undelegatable, true);
 }
@@ -159,7 +173,9 @@ async fn test_commit_finalize_out_of_order() {
     );
 }
 
-async fn setup_program_test_env(pda_data: Vec<u8>) -> (BanksClient, Keypair, Keypair, Hash) {
+async fn setup_program_test_env(
+    pda_data: Vec<u8>,
+) -> (BanksClient, Keypair, Keypair, Hash) {
     let mut program_test = ProgramTest::new("dlp", dlp::ID, None);
     program_test.prefer_bpf(true);
 
@@ -189,11 +205,13 @@ async fn setup_program_test_env(pda_data: Vec<u8>) -> (BanksClient, Keypair, Key
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator_keypair.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -202,11 +220,13 @@ async fn setup_program_test_env(pda_data: Vec<u8>) -> (BanksClient, Keypair, Key
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator_keypair.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_commit_finalize_from_buffer.rs
+++ b/tests/test_commit_finalize_from_buffer.rs
@@ -1,21 +1,28 @@
-use dlp::args::CommitFinalizeArgs;
-use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitFinalizeArgs,
+    pda::{
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::DelegationMetadata,
 };
-use dlp::state::DelegationMetadata;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
-use solana_program_test::{BanksClient, BanksTransactionResultWithMetadata, ProgramTest};
-use solana_sdk::pubkey::Pubkey;
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
+use solana_program_test::{
+    BanksClient, BanksTransactionResultWithMetadata, ProgramTest,
+};
 use solana_sdk::{
     account::Account,
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 
 use crate::fixtures::{
-    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID, TEST_AUTHORITY,
+    get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
+    TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -29,7 +36,8 @@ async fn test_commit_finalize_from_buffer_perf() {
         setup_program_test_env(vec![0; 10240], new_state.clone()).await;
 
     let new_account_balance = 1_000_000;
-    let state_buffer_pda = Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
+    let state_buffer_pda =
+        Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
 
     let (ix, pdas) = dlp::instruction_builder::commit_finalize_from_buffer(
         authority.pubkey(),
@@ -69,7 +77,8 @@ async fn test_commit_finalize_from_buffer_perf() {
         );
     }
 
-    let delegated_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert_eq!(delegated_account.data, new_state);
 
     let delegation_metadata_account = banks
@@ -79,8 +88,10 @@ async fn test_commit_finalize_from_buffer_perf() {
         .unwrap();
 
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
 
     assert_eq!(delegation_metadata.is_undelegatable, true);
 }
@@ -89,9 +100,11 @@ async fn test_commit_finalize_from_buffer_perf() {
 async fn test_commit_finalize_from_buffer_out_of_order() {
     // Setup
     let (banks, _, authority, blockhash) =
-        setup_program_test_env(vec![], vec![0, 1, 2, 9, 9, 9, 6, 7, 8, 9]).await;
+        setup_program_test_env(vec![], vec![0, 1, 2, 9, 9, 9, 6, 7, 8, 9])
+            .await;
 
-    let state_buffer_pda = Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
+    let state_buffer_pda =
+        Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
     let new_account_balance = 1_000_000;
 
     let (ix, _pdas) = dlp::instruction_builder::commit_finalize_from_buffer(
@@ -179,11 +192,13 @@ async fn setup_program_test_env(
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator_keypair.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -192,11 +207,13 @@ async fn setup_program_test_env(
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator_keypair.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -217,7 +234,11 @@ async fn setup_program_test_env(
     );
 
     program_test.add_account(
-        Pubkey::find_program_address(&[b"state_buffer"], &validator_keypair.pubkey()).0,
+        Pubkey::find_program_address(
+            &[b"state_buffer"],
+            &validator_keypair.pubkey(),
+        )
+        .0,
         Account {
             lamports: LAMPORTS_PER_SOL,
             data: pda_new_state,

--- a/tests/test_commit_on_curve.rs
+++ b/tests/test_commit_on_curve.rs
@@ -1,12 +1,17 @@
-use dlp::args::CommitStateArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitStateArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
 };
-use dlp::state::{CommitRecord, DelegationMetadata};
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -15,8 +20,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    get_delegation_metadata_data_on_curve, get_delegation_record_on_curve_data, ON_CURVE_KEYPAIR,
-    TEST_AUTHORITY,
+    get_delegation_metadata_data_on_curve, get_delegation_record_on_curve_data,
+    ON_CURVE_KEYPAIR, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -24,7 +29,8 @@ mod fixtures;
 #[tokio::test]
 async fn test_commit_on_curve() {
     // Setup
-    let (banks, payer_delegated, validator, blockhash) = setup_program_test_env().await;
+    let (banks, payer_delegated, validator, blockhash) =
+        setup_program_test_env().await;
 
     let new_account_balance = 1_000_000;
     let commit_args = CommitStateArgs {
@@ -52,29 +58,39 @@ async fn test_commit_on_curve() {
     assert!(res.is_ok());
 
     // Assert the state commitment was created and contains the new state
-    let commit_state_pda = commit_state_pda_from_delegated_account(&payer_delegated.pubkey());
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&payer_delegated.pubkey());
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap().unwrap();
     assert!(commit_state_account.data.is_empty());
 
     // Assert the record about the commitment exists
-    let commit_record_pda = commit_record_pda_from_delegated_account(&payer_delegated.pubkey());
-    let commit_record_account = banks.get_account(commit_record_pda).await.unwrap().unwrap();
-    let commit_record =
-        CommitRecord::try_from_bytes_with_discriminator(&commit_record_account.data).unwrap();
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&payer_delegated.pubkey());
+    let commit_record_account =
+        banks.get_account(commit_record_pda).await.unwrap().unwrap();
+    let commit_record = CommitRecord::try_from_bytes_with_discriminator(
+        &commit_record_account.data,
+    )
+    .unwrap();
     assert_eq!(commit_record.account, payer_delegated.pubkey());
     assert_eq!(commit_record.identity, validator.pubkey());
     assert_eq!(commit_record.nonce, 1);
 
     let delegation_metadata_pda =
-        delegation_metadata_pda_from_delegated_account(&payer_delegated.pubkey());
+        delegation_metadata_pda_from_delegated_account(
+            &payer_delegated.pubkey(),
+        );
     let delegation_metadata_account = banks
         .get_account(delegation_metadata_pda)
         .await
         .unwrap()
         .unwrap();
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
     assert!(delegation_metadata.is_undelegatable);
 }
 
@@ -109,8 +125,10 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data =
-        get_delegation_record_on_curve_data(validator_keypair.pubkey(), Some(LAMPORTS_PER_SOL));
+    let delegation_record_data = get_delegation_record_on_curve_data(
+        validator_keypair.pubkey(),
+        Some(LAMPORTS_PER_SOL),
+    );
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&payer_alt.pubkey()),
         Account {
@@ -128,7 +146,8 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&payer_alt.pubkey()),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_commit_state.rs
+++ b/tests/test_commit_state.rs
@@ -1,12 +1,17 @@
-use dlp::args::CommitStateArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitStateArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
 };
-use dlp::state::{CommitRecord, DelegationMetadata};
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -53,32 +58,45 @@ async fn test_commit_new_state() {
     assert!(res.is_ok());
 
     // Assert the state commitment was created and contains the new state
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap().unwrap();
     assert_eq!(commit_state_account.data, new_state.clone());
 
     // Check that the commit has enough collateral to finalize the proposed state diff
-    let delegated_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
-    assert!(new_account_balance < commit_state_account.lamports + delegated_account.lamports);
+    let delegated_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    assert!(
+        new_account_balance
+            < commit_state_account.lamports + delegated_account.lamports
+    );
 
     // Assert the record about the commitment exists
-    let commit_record_pda = commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_record_account = banks.get_account(commit_record_pda).await.unwrap().unwrap();
-    let commit_record =
-        CommitRecord::try_from_bytes_with_discriminator(&commit_record_account.data).unwrap();
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_record_account =
+        banks.get_account(commit_record_pda).await.unwrap().unwrap();
+    let commit_record = CommitRecord::try_from_bytes_with_discriminator(
+        &commit_record_account.data,
+    )
+    .unwrap();
     assert_eq!(commit_record.account, DELEGATED_PDA_ID);
     assert_eq!(commit_record.identity, authority.pubkey());
     assert_eq!(commit_record.nonce, 1);
 
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
     let delegation_metadata_account = banks
         .get_account(delegation_metadata_pda)
         .await
         .unwrap()
         .unwrap();
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
     assert!(delegation_metadata.is_undelegatable);
 }
 
@@ -149,11 +167,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator_keypair.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -162,11 +182,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator_keypair.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_commit_state_from_buffer.rs
+++ b/tests/test_commit_state_from_buffer.rs
@@ -1,22 +1,28 @@
+use dlp::{
+    args::CommitStateFromBufferArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
+use solana_program_test::{BanksClient, ProgramTest};
+use solana_sdk::{
+    account::Account,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
 use crate::fixtures::{
     get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
     DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
-};
-use dlp::args::CommitStateFromBufferArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
-};
-use dlp::state::{CommitRecord, DelegationMetadata};
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
-use solana_program_test::{BanksClient, ProgramTest};
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::{
-    account::Account,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
 };
 
 mod fixtures;
@@ -28,7 +34,8 @@ async fn test_commit_new_state_from_buffer() {
     // Setup
     let (banks, _, authority, blockhash) = setup_program_test_env().await;
     let new_account_balance = 1_000_000;
-    let state_buffer_pda = Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
+    let state_buffer_pda =
+        Pubkey::find_program_address(&[b"state_buffer"], &authority.pubkey()).0;
 
     let commit_args = CommitStateFromBufferArgs {
         nonce: 1,
@@ -55,32 +62,45 @@ async fn test_commit_new_state_from_buffer() {
     assert!(res.is_ok());
 
     // Assert the state commitment was created and contains the new state
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap().unwrap();
     assert_eq!(commit_state_account.data, NEW_STATE.to_vec());
 
     // Check that the commit has enough collateral to finalize the proposed state diff
-    let delegated_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
-    assert!(new_account_balance < commit_state_account.lamports + delegated_account.lamports);
+    let delegated_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    assert!(
+        new_account_balance
+            < commit_state_account.lamports + delegated_account.lamports
+    );
 
     // Assert the record about the commitment exists
-    let commit_record_pda = commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_record_account = banks.get_account(commit_record_pda).await.unwrap().unwrap();
-    let commit_record =
-        CommitRecord::try_from_bytes_with_discriminator(&commit_record_account.data).unwrap();
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_record_account =
+        banks.get_account(commit_record_pda).await.unwrap().unwrap();
+    let commit_record = CommitRecord::try_from_bytes_with_discriminator(
+        &commit_record_account.data,
+    )
+    .unwrap();
     assert_eq!(commit_record.account, DELEGATED_PDA_ID);
     assert_eq!(commit_record.identity, authority.pubkey());
     assert_eq!(commit_record.nonce, 1);
 
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
     let delegation_metadata_account = banks
         .get_account(delegation_metadata_pda)
         .await
         .unwrap()
         .unwrap();
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
     assert!(delegation_metadata.is_undelegatable);
 }
 
@@ -114,11 +134,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator_keypair.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -127,11 +149,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator_keypair.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -153,7 +177,11 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
 
     // Setup a state buffer account
     program_test.add_account(
-        Pubkey::find_program_address(&[b"state_buffer"], &validator_keypair.pubkey()).0,
+        Pubkey::find_program_address(
+            &[b"state_buffer"],
+            &validator_keypair.pubkey(),
+        )
+        .0,
         Account {
             lamports: LAMPORTS_PER_SOL,
             data: NEW_STATE.to_vec(),

--- a/tests/test_commit_state_with_program_config.rs
+++ b/tests/test_commit_state_with_program_config.rs
@@ -1,13 +1,19 @@
-use dlp::args::CommitStateArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    program_config_from_program_id, validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitStateArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        program_config_from_program_id,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
 };
-use dlp::state::{CommitRecord, DelegationMetadata};
 use fixtures::create_program_config_data;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -34,7 +40,8 @@ async fn test_commit_new_state_invalid_config() {
 
 async fn test_commit_new_state(valid_config: bool) {
     // Setup
-    let (banks, _, authority, blockhash) = setup_program_test_env(valid_config).await;
+    let (banks, _, authority, blockhash) =
+        setup_program_test_env(valid_config).await;
     let new_state = vec![0, 1, 2, 9, 9, 9, 6, 7, 8, 9];
 
     let new_account_balance = 1_000_000;
@@ -66,19 +73,29 @@ async fn test_commit_new_state(valid_config: bool) {
         assert!(res.is_ok());
 
         // Assert the state commitment was created and contains the new state
-        let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
-        let commit_state_account = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+        let commit_state_pda =
+            commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+        let commit_state_account =
+            banks.get_account(commit_state_pda).await.unwrap().unwrap();
         assert_eq!(commit_state_account.data, new_state.clone());
 
         // Check that the commit has enough collateral to finalize the proposed state diff
-        let delegated_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
-        assert!(new_account_balance < commit_state_account.lamports + delegated_account.lamports);
+        let delegated_account =
+            banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+        assert!(
+            new_account_balance
+                < commit_state_account.lamports + delegated_account.lamports
+        );
 
         // Assert the record about the commitment exists
-        let commit_record_pda = commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-        let commit_record_account = banks.get_account(commit_record_pda).await.unwrap().unwrap();
-        let commit_record =
-            CommitRecord::try_from_bytes_with_discriminator(&commit_record_account.data).unwrap();
+        let commit_record_pda =
+            commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+        let commit_record_account =
+            banks.get_account(commit_record_pda).await.unwrap().unwrap();
+        let commit_record = CommitRecord::try_from_bytes_with_discriminator(
+            &commit_record_account.data,
+        )
+        .unwrap();
         assert_eq!(commit_record.account, DELEGATED_PDA_ID);
         assert_eq!(commit_record.identity, authority.pubkey());
         assert_eq!(commit_record.nonce, 1);
@@ -90,15 +107,18 @@ async fn test_commit_new_state(valid_config: bool) {
             .await
             .unwrap()
             .unwrap();
-        let delegation_metadata = DelegationMetadata::try_from_bytes_with_discriminator(
-            &delegation_metadata_account.data,
-        )
-        .unwrap();
+        let delegation_metadata =
+            DelegationMetadata::try_from_bytes_with_discriminator(
+                &delegation_metadata_account.data,
+            )
+            .unwrap();
         assert!(delegation_metadata.is_undelegatable);
     }
 }
 
-async fn setup_program_test_env(valid_config: bool) -> (BanksClient, Keypair, Keypair, Hash) {
+async fn setup_program_test_env(
+    valid_config: bool,
+) -> (BanksClient, Keypair, Keypair, Hash) {
     let mut program_test = ProgramTest::new("dlp", dlp::ID, None);
     program_test.prefer_bpf(true);
 
@@ -128,11 +148,13 @@ async fn setup_program_test_env(valid_config: bool) -> (BanksClient, Keypair, Ke
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator_keypair.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,
@@ -141,11 +163,13 @@ async fn setup_program_test_env(valid_config: bool) -> (BanksClient, Keypair, Ke
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator_keypair.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator_keypair.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -174,7 +198,8 @@ async fn setup_program_test_env(valid_config: bool) -> (BanksClient, Keypair, Ke
     program_test.add_account(
         program_config_from_program_id(&DELEGATED_PDA_OWNER_ID),
         Account {
-            lamports: Rent::default().minimum_balance(program_config_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(program_config_data.len()),
             data: program_config_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_commit_undelegate_zero_lamports_system_owned.rs
+++ b/tests/test_commit_undelegate_zero_lamports_system_owned.rs
@@ -1,11 +1,16 @@
-use dlp::args::CommitStateArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, validator_fees_vault_pda_from_validator,
+use dlp::{
+    args::CommitStateArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -14,8 +19,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    create_delegation_record_data, get_delegation_metadata_data, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
+    create_delegation_record_data, get_delegation_metadata_data,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -25,7 +30,8 @@ async fn test_commit_and_undelegate_zero_lamports_system_owned_account() {
     // Setup
     let (banks, _, validator, blockhash) = setup_program_test_env().await;
 
-    let delegated_account_before = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let delegated_account_before =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
 
     // Assert that the account is delegated, with some lamports and owned by dlp
     assert!(delegated_account_before.lamports > 0);
@@ -53,7 +59,10 @@ async fn test_commit_and_undelegate_zero_lamports_system_owned_account() {
     let res_commit = banks.process_transaction(tx_commit).await;
     assert!(res_commit.is_ok());
 
-    let ix_finalize = dlp::instruction_builder::finalize(validator.pubkey(), DELEGATED_PDA_ID);
+    let ix_finalize = dlp::instruction_builder::finalize(
+        validator.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let ix_undelegate = dlp::instruction_builder::undelegate(
         validator.pubkey(),
         DELEGATED_PDA_ID,
@@ -69,24 +78,33 @@ async fn test_commit_and_undelegate_zero_lamports_system_owned_account() {
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap();
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap();
     assert!(commit_state_account.is_none());
 
-    let commit_record_pda = commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_record_account = banks.get_account(commit_record_pda).await.unwrap();
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_record_account =
+        banks.get_account(commit_record_pda).await.unwrap();
     assert!(commit_record_account.is_none());
 
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_metadata_account = banks.get_account(delegation_metadata_pda).await.unwrap();
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_account =
+        banks.get_account(delegation_metadata_pda).await.unwrap();
     assert!(delegation_metadata_account.is_none());
 
     // Assert the account was closed
-    let delegated_account_after = banks.get_account(DELEGATED_PDA_ID).await.unwrap();
+    let delegated_account_after =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap();
     assert!(delegated_account_after.is_none());
 }
 
@@ -130,7 +148,8 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -138,11 +157,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
         },
     );
 
-    let delegation_metadata_data = get_delegation_metadata_data(validator.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_delegate.rs
+++ b/tests/test_delegate.rs
@@ -1,22 +1,26 @@
-use solana_program::pubkey::Pubkey;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use dlp::{
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+    },
+    state::DelegationRecord,
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, rent::Rent,
+    system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
-use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::{
     account::Account,
+    instruction::{AccountMeta, Instruction},
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 
-use dlp::pda::{
-    delegate_buffer_pda_from_delegated_account_and_owner_program,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-};
-use dlp::state::DelegationRecord;
-
 use crate::fixtures::{
-    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, EXTERNAL_DELEGATE_INSTRUCTION_DISCRIMINATOR,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID,
+    EXTERNAL_DELEGATE_INSTRUCTION_DISCRIMINATOR,
 };
 
 mod fixtures;
@@ -27,35 +31,44 @@ async fn test_delegate() {
     let (banks, payer, _, blockhash) = setup_program_test_env().await;
 
     // Save the PDA before delegation
-    let pda_before_delegation = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_before_delegation =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     let pda_data_before_delegation = pda_before_delegation.data.clone();
 
     // Submit the delegate tx
     let ix = delegate_from_wrapper_program(payer.pubkey(), DELEGATED_PDA_ID);
 
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
 
     println!("{:?}", res);
     assert!(res.is_ok());
 
     // Assert the buffer was closed
-    let delegate_buffer_pda = delegate_buffer_pda_from_delegated_account_and_owner_program(
-        &DELEGATED_PDA_ID,
-        &DELEGATED_PDA_OWNER_ID,
-    );
+    let delegate_buffer_pda =
+        delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &DELEGATED_PDA_ID,
+            &DELEGATED_PDA_OWNER_ID,
+        );
     let buffer_account = banks.get_account(delegate_buffer_pda).await.unwrap();
     assert!(buffer_account.is_none());
 
     // Assert the PDA was delegated => owner is set to the delegation program
-    let pda_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert!(pda_account.owner.eq(&dlp::id()));
 
     // Assert the PDA data was not changed
     assert_eq!(pda_data_before_delegation, pda_account.data);
 
     // Assert that the PDA seeds account exists
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
     let delegation_metadata_account = banks
         .get_account(delegation_metadata_pda)
         .await
@@ -72,7 +85,10 @@ async fn test_delegate() {
         .unwrap()
         .unwrap();
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record.data).unwrap();
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record.data,
+        )
+        .unwrap();
     assert_eq!(delegation_record.owner, DELEGATED_PDA_OWNER_ID);
 }
 
@@ -123,12 +139,17 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
 }
 
 /// Builds a delegate instruction for the test program
-fn delegate_from_wrapper_program(payer: Pubkey, delegated_account: Pubkey) -> Instruction {
-    let delegate_buffer_pda = delegate_buffer_pda_from_delegated_account_and_owner_program(
-        &delegated_account,
-        &DELEGATED_PDA_OWNER_ID,
-    );
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&delegated_account);
+fn delegate_from_wrapper_program(
+    payer: Pubkey,
+    delegated_account: Pubkey,
+) -> Instruction {
+    let delegate_buffer_pda =
+        delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &delegated_account,
+            &DELEGATED_PDA_OWNER_ID,
+        );
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&delegated_account);
     let delegation_metadata_pda =
         delegation_metadata_pda_from_delegated_account(&delegated_account);
     Instruction {

--- a/tests/test_delegate_on_curve.rs
+++ b/tests/test_delegate_on_curve.rs
@@ -1,4 +1,15 @@
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use dlp::{
+    args::DelegateArgs,
+    pda::{
+        delegate_buffer_pda_from_delegated_account_and_owner_program,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+    },
+    state::{DelegationMetadata, DelegationRecord},
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -7,12 +18,6 @@ use solana_sdk::{
 };
 
 use crate::fixtures::ON_CURVE_KEYPAIR;
-use dlp::args::DelegateArgs;
-use dlp::pda::{
-    delegate_buffer_pda_from_delegated_account_and_owner_program,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-};
-use dlp::state::{DelegationMetadata, DelegationRecord};
 
 mod fixtures;
 
@@ -25,8 +30,10 @@ async fn test_delegate_on_curve() {
     let delegated_account = alt_payer.pubkey();
 
     // Create transaction to change the owner of alt_payer
-    let change_owner_ix =
-        solana_program::system_instruction::assign(&alt_payer.pubkey(), &dlp::id());
+    let change_owner_ix = solana_program::system_instruction::assign(
+        &alt_payer.pubkey(),
+        &dlp::id(),
+    );
 
     let change_owner_tx = Transaction::new_signed_with_payer(
         &[change_owner_ix],
@@ -71,15 +78,17 @@ async fn test_delegate_on_curve() {
     assert!(res.is_ok());
 
     // Assert the buffer doesn't exist
-    let delegate_buffer_pda = delegate_buffer_pda_from_delegated_account_and_owner_program(
-        &delegated_account,
-        &system_program::id(),
-    );
+    let delegate_buffer_pda =
+        delegate_buffer_pda_from_delegated_account_and_owner_program(
+            &delegated_account,
+            &system_program::id(),
+        );
     let buffer_account = banks.get_account(delegate_buffer_pda).await.unwrap();
     assert!(buffer_account.is_none());
 
     // Assert the PDA was delegated => owner is set to the delegation program
-    let pda_account = banks.get_account(delegated_account).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(delegated_account).await.unwrap().unwrap();
     assert!(pda_account.owner.eq(&dlp::id()));
 
     // Assert that the PDA seeds account exists
@@ -101,8 +110,10 @@ async fn test_delegate_on_curve() {
         .unwrap()
         .unwrap();
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_account.data)
-            .unwrap();
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_account.data,
+        )
+        .unwrap();
     assert_eq!(delegation_record.owner, system_program::id());
     assert_eq!(delegation_record.authority, alt_payer.pubkey());
 
@@ -116,7 +127,10 @@ async fn test_delegate_on_curve() {
         .unwrap();
     assert!(delegation_metadata.owner.eq(&dlp::id()));
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata.data).unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata.data,
+        )
+        .unwrap();
     assert!(!delegation_metadata.is_undelegatable);
 }
 

--- a/tests/test_delegation_confined_accounts.rs
+++ b/tests/test_delegation_confined_accounts.rs
@@ -1,4 +1,10 @@
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use dlp::{
+    args::DelegateArgs, error::DlpError,
+    pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, system_program,
+};
 use solana_program_test::{BanksClient, BanksClientError, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -6,11 +12,6 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::{Transaction, TransactionError},
 };
-
-use dlp::args::DelegateArgs;
-use dlp::error::DlpError;
-use dlp::pda::delegation_record_pda_from_delegated_account;
-use dlp::state::DelegationRecord;
 
 use crate::fixtures::ON_CURVE_KEYPAIR;
 
@@ -20,7 +21,10 @@ mod fixtures;
 async fn test_delegation_confined_accounts_rejects_system_validator() {
     let (banks, payer, delegated, blockhash) = setup_program_test_env().await;
 
-    let assign_ix = solana_program::system_instruction::assign(&delegated.pubkey(), &dlp::id());
+    let assign_ix = solana_program::system_instruction::assign(
+        &delegated.pubkey(),
+        &dlp::id(),
+    );
     let assign_tx = Transaction::new_signed_with_payer(
         &[assign_ix],
         Some(&delegated.pubkey()),
@@ -49,11 +53,16 @@ async fn test_delegation_confined_accounts_rejects_system_validator() {
     let res = banks.process_transaction(tx).await;
     let err = res.unwrap_err();
     match err {
-        BanksClientError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(code),
-        )) => {
-            assert_eq!(code, DlpError::DelegationToSystemProgramNotAllowed as u32);
+        BanksClientError::TransactionError(
+            TransactionError::InstructionError(
+                _,
+                InstructionError::Custom(code),
+            ),
+        ) => {
+            assert_eq!(
+                code,
+                DlpError::DelegationToSystemProgramNotAllowed as u32
+            );
         }
         _ => panic!("unexpected error: {err:?}"),
     }
@@ -63,7 +72,10 @@ async fn test_delegation_confined_accounts_rejects_system_validator() {
 async fn test_delegation_confined_accounts_allows_system_validator() {
     let (banks, payer, delegated, blockhash) = setup_program_test_env().await;
 
-    let assign_ix = solana_program::system_instruction::assign(&delegated.pubkey(), &dlp::id());
+    let assign_ix = solana_program::system_instruction::assign(
+        &delegated.pubkey(),
+        &dlp::id(),
+    );
     let assign_tx = Transaction::new_signed_with_payer(
         &[assign_ix],
         Some(&delegated.pubkey()),
@@ -100,8 +112,10 @@ async fn test_delegation_confined_accounts_allows_system_validator() {
         .expect("failed to fetch delegation record account")
         .expect("delegation record account missing for delegated pubkey");
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_account.data)
-            .expect("failed to deserialize DelegationRecord for delegated pubkey");
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_account.data,
+        )
+        .expect("failed to deserialize DelegationRecord for delegated pubkey");
     assert_eq!(delegation_record.authority, system_program::id());
 }
 

--- a/tests/test_finalize.rs
+++ b/tests/test_finalize.rs
@@ -1,20 +1,27 @@
-use crate::fixtures::{
-    get_commit_record_account_data, get_delegation_metadata_data, get_delegation_record_data,
-    COMMIT_NEW_STATE_ACCOUNT_DATA, DELEGATED_PDA_ID, TEST_AUTHORITY,
+use dlp::{
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
 };
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    validator_fees_vault_pda_from_validator,
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
 };
-use dlp::state::{CommitRecord, DelegationMetadata};
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
+};
+
+use crate::fixtures::{
+    get_commit_record_account_data, get_delegation_metadata_data,
+    get_delegation_record_data, COMMIT_NEW_STATE_ACCOUNT_DATA,
+    DELEGATED_PDA_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -25,21 +32,30 @@ async fn test_finalize() {
     let (banks, _, authority, blockhash) = setup_program_test_env().await;
 
     // Retrieve the accounts
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_record_pda = commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
 
     // Commit state record data
-    let commit_record = banks.get_account(commit_record_pda).await.unwrap().unwrap();
     let commit_record =
-        CommitRecord::try_from_bytes_with_discriminator(&commit_record.data).unwrap();
+        banks.get_account(commit_record_pda).await.unwrap().unwrap();
+    let commit_record =
+        CommitRecord::try_from_bytes_with_discriminator(&commit_record.data)
+            .unwrap();
 
     // Save the new state data before finalizing
-    let new_state_before_finalize = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+    let new_state_before_finalize =
+        banks.get_account(commit_state_pda).await.unwrap().unwrap();
     let new_state_data_before_finalize = new_state_before_finalize.data.clone();
 
     // Submit the finalize tx
-    let ix = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let ix = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&authority.pubkey()),
@@ -51,34 +67,41 @@ async fn test_finalize() {
     assert!(res.is_ok());
 
     // Assert the state_diff was closed
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap();
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap();
     assert!(commit_state_account.is_none());
 
     // Assert the delegation_record was not closed
-    let delegation_record = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record.is_some());
 
     // Assert the commit_record_pda was closed
-    let commit_record_account = banks.get_account(commit_record_pda).await.unwrap();
+    let commit_record_account =
+        banks.get_account(commit_record_pda).await.unwrap();
     assert!(commit_record_account.is_none());
 
     // Assert that the account owner is still the delegation program
-    let pda_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert!(pda_account.owner.eq(&dlp::id()));
 
     // Assert the delegated account contains the data from the new state
     assert_eq!(new_state_data_before_finalize, pda_account.data);
 
     // Assert the delegation metadata contains the correct slot of the commitment
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
     let delegation_metadata_account = banks
         .get_account(delegation_metadata_pda)
         .await
         .unwrap()
         .unwrap();
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
     assert_eq!(commit_record.nonce, delegation_metadata.last_update_nonce);
 }
 
@@ -112,11 +135,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegation record PDA
-    let delegation_record_data = get_delegation_record_data(authority.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(authority.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data.clone(),
             owner: dlp::id(),
             executable: false,
@@ -125,11 +150,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(authority.pubkey(), None);
+    let delegation_metadata_data =
+        get_delegation_metadata_data(authority.pubkey(), None);
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_init_fees_vault.rs
+++ b/tests/test_init_fees_vault.rs
@@ -1,5 +1,7 @@
 use dlp::pda::fees_vault_pda;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -15,7 +17,12 @@ async fn test_init_fees_vault() {
     let (banks, payer, _, blockhash) = setup_program_test_env().await;
 
     let ix = dlp::instruction_builder::init_protocol_fees_vault(payer.pubkey());
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 

--- a/tests/test_init_validator_fees_vault.rs
+++ b/tests/test_init_validator_fees_vault.rs
@@ -1,13 +1,15 @@
-use crate::fixtures::TEST_AUTHORITY;
 use dlp::pda::validator_fees_vault_pda_from_validator;
-use solana_program::pubkey::Pubkey;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+
+use crate::fixtures::TEST_AUTHORITY;
 
 mod fixtures;
 
@@ -32,8 +34,10 @@ async fn test_init_validator_fees_vault() {
     assert!(res.is_ok());
 
     // Assert the fees vault was created successfully
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator_identity);
-    let validator_fees_vault_account = banks.get_account(validator_fees_vault_pda).await.unwrap();
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator_identity);
+    let validator_fees_vault_account =
+        banks.get_account(validator_fees_vault_pda).await.unwrap();
     assert!(validator_fees_vault_account.is_some());
 
     // Assert record cannot be created if the admin is not the correct one
@@ -43,7 +47,12 @@ async fn test_init_validator_fees_vault() {
         payer.pubkey(),
         validator_identity,
     );
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_err());
 }

--- a/tests/test_lamports_settlement.rs
+++ b/tests/test_lamports_settlement.rs
@@ -1,23 +1,29 @@
-use crate::fixtures::{
-    create_delegation_record_data, get_delegation_metadata_data,
-    get_delegation_metadata_data_on_curve, COMMIT_NEW_STATE_ACCOUNT_DATA, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, ON_CURVE_KEYPAIR, TEST_AUTHORITY,
+use dlp::{
+    args::CommitStateArgs,
+    pda::{
+        commit_record_pda_from_delegated_account,
+        commit_state_pda_from_delegated_account,
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::{CommitRecord, DelegationMetadata},
 };
-use dlp::args::CommitStateArgs;
-use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, rent::Rent,
+    system_program,
 };
-use dlp::state::{CommitRecord, DelegationMetadata};
-use solana_program::pubkey::Pubkey;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
+};
+
+use crate::fixtures::{
+    create_delegation_record_data, get_delegation_metadata_data,
+    get_delegation_metadata_data_on_curve, COMMIT_NEW_STATE_ACCOUNT_DATA,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, ON_CURVE_KEYPAIR, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -63,43 +69,75 @@ async fn test_commit_undelegate_pda_after_balance_increase() {
 }
 
 #[tokio::test]
-async fn test_commit_finalise_system_account_after_balance_decrease_and_increase_mainchain() {
-    test_commit_system_account_after_balance_decrease_and_increase_mainchain(false, false).await;
+async fn test_commit_finalise_system_account_after_balance_decrease_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_decrease_and_increase_mainchain(
+        false, false,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_undelegate_system_account_after_balance_decrease_and_increase_mainchain() {
-    test_commit_system_account_after_balance_decrease_and_increase_mainchain(true, false).await;
+async fn test_commit_undelegate_system_account_after_balance_decrease_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_decrease_and_increase_mainchain(
+        true, false,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_finalise_pda_after_balance_decrease_and_increase_mainchain() {
-    test_commit_system_account_after_balance_decrease_and_increase_mainchain(false, true).await;
+async fn test_commit_finalise_pda_after_balance_decrease_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_decrease_and_increase_mainchain(
+        false, true,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_undelegate_pda_after_balance_decrease_and_increase_mainchain() {
-    test_commit_system_account_after_balance_decrease_and_increase_mainchain(true, true).await;
+async fn test_commit_undelegate_pda_after_balance_decrease_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_decrease_and_increase_mainchain(
+        true, true,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_finalise_system_account_after_balance_increase_and_increase_mainchain() {
-    test_commit_system_account_after_balance_increase_and_increase_mainchain(false, false).await;
+async fn test_commit_finalise_system_account_after_balance_increase_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_increase_and_increase_mainchain(
+        false, false,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_undelegate_system_account_after_balance_increase_and_increase_mainchain() {
-    test_commit_system_account_after_balance_increase_and_increase_mainchain(true, false).await;
+async fn test_commit_undelegate_system_account_after_balance_increase_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_increase_and_increase_mainchain(
+        true, false,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_finalise_pda_after_balance_increase_and_increase_mainchain() {
-    test_commit_system_account_after_balance_increase_and_increase_mainchain(false, true).await;
+async fn test_commit_finalise_pda_after_balance_increase_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_increase_and_increase_mainchain(
+        false, true,
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_commit_undelegate_pda_after_balance_increase_and_increase_mainchain() {
-    test_commit_system_account_after_balance_increase_and_increase_mainchain(true, true).await;
+async fn test_commit_undelegate_pda_after_balance_increase_and_increase_mainchain(
+) {
+    test_commit_system_account_after_balance_increase_and_increase_mainchain(
+        true, true,
+    )
+    .await;
 }
 
 pub async fn test_commit_system_account_after_balance_decrease(
@@ -107,7 +145,8 @@ pub async fn test_commit_system_account_after_balance_decrease(
     is_pda: bool,
 ) {
     // Setup
-    let (delegated_account, owner_program) = get_delegated_account_and_owner(is_pda);
+    let (delegated_account, owner_program) =
+        get_delegated_account_and_owner(is_pda);
     let (mut banks, _, authority, blockhash) =
         setup_program_for_commit_test_env(SetupProgramCommitTestEnvArgs {
             delegated_account_init_lamports: LAMPORTS_PER_SOL,
@@ -141,21 +180,30 @@ pub async fn test_commit_system_account_after_balance_decrease(
     .await;
 
     // Assert finalized lamports balance is correct
-    let delegated_account = banks.get_account(delegated_account).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(delegated_account).await.unwrap().unwrap();
     assert_eq!(delegated_account.lamports, new_delegated_account_lamports);
 
     // Assert the vault own the difference
     let validator_vault = banks
-        .get_account(validator_fees_vault_pda_from_validator(&authority.pubkey()))
+        .get_account(validator_fees_vault_pda_from_validator(
+            &authority.pubkey(),
+        ))
         .await
         .unwrap()
         .unwrap();
-    assert!(validator_vault.lamports >= Rent::default().minimum_balance(0) + 100);
+    assert!(
+        validator_vault.lamports >= Rent::default().minimum_balance(0) + 100
+    );
 }
 
-async fn test_commit_system_account_after_balance_increase(also_undelegate: bool, is_pda: bool) {
+async fn test_commit_system_account_after_balance_increase(
+    also_undelegate: bool,
+    is_pda: bool,
+) {
     // Setup
-    let (delegated_account, owner_program) = get_delegated_account_and_owner(is_pda);
+    let (delegated_account, owner_program) =
+        get_delegated_account_and_owner(is_pda);
     let (mut banks, _, authority, blockhash) =
         setup_program_for_commit_test_env(SetupProgramCommitTestEnvArgs {
             delegated_account_init_lamports: LAMPORTS_PER_SOL,
@@ -189,12 +237,15 @@ async fn test_commit_system_account_after_balance_increase(also_undelegate: bool
     .await;
 
     // Assert finalized lamports balance is correct
-    let delegated_account = banks.get_account(delegated_account).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(delegated_account).await.unwrap().unwrap();
     assert_eq!(delegated_account.lamports, new_delegated_account_lamports);
 
     // Assert the vault own the difference
     let validator_vault = banks
-        .get_account(validator_fees_vault_pda_from_validator(&authority.pubkey()))
+        .get_account(validator_fees_vault_pda_from_validator(
+            &authority.pubkey(),
+        ))
         .await
         .unwrap()
         .unwrap();
@@ -206,7 +257,8 @@ async fn test_commit_system_account_after_balance_decrease_and_increase_mainchai
     is_pda: bool,
 ) {
     // Setup
-    let (delegated_account, owner_program) = get_delegated_account_and_owner(is_pda);
+    let (delegated_account, owner_program) =
+        get_delegated_account_and_owner(is_pda);
     let (mut banks, _, authority, blockhash) =
         setup_program_for_commit_test_env(SetupProgramCommitTestEnvArgs {
             delegated_account_init_lamports: LAMPORTS_PER_SOL,
@@ -240,7 +292,8 @@ async fn test_commit_system_account_after_balance_decrease_and_increase_mainchai
     .await;
 
     // Assert finalized lamports balance is correct
-    let delegated_account = banks.get_account(delegated_account).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(delegated_account).await.unwrap().unwrap();
     assert_eq!(
         delegated_account.lamports,
         new_delegated_account_lamports + 9000
@@ -248,7 +301,9 @@ async fn test_commit_system_account_after_balance_decrease_and_increase_mainchai
 
     // Assert the vault own the difference
     let validator_vault = banks
-        .get_account(validator_fees_vault_pda_from_validator(&authority.pubkey()))
+        .get_account(validator_fees_vault_pda_from_validator(
+            &authority.pubkey(),
+        ))
         .await
         .unwrap()
         .unwrap();
@@ -260,7 +315,8 @@ async fn test_commit_system_account_after_balance_increase_and_increase_mainchai
     is_pda: bool,
 ) {
     // Setup
-    let (delegated_account, owner_program) = get_delegated_account_and_owner(is_pda);
+    let (delegated_account, owner_program) =
+        get_delegated_account_and_owner(is_pda);
     let (mut banks, _, authority, blockhash) =
         setup_program_for_commit_test_env(SetupProgramCommitTestEnvArgs {
             delegated_account_init_lamports: LAMPORTS_PER_SOL,
@@ -294,7 +350,8 @@ async fn test_commit_system_account_after_balance_increase_and_increase_mainchai
     .await;
 
     // Assert finalized lamports balance is correct
-    let delegated_account = banks.get_account(delegated_account).await.unwrap().unwrap();
+    let delegated_account =
+        banks.get_account(delegated_account).await.unwrap().unwrap();
     assert_eq!(
         delegated_account.lamports,
         new_delegated_account_lamports + 8200
@@ -302,7 +359,9 @@ async fn test_commit_system_account_after_balance_increase_and_increase_mainchai
 
     // Assert the vault own the difference
     let validator_vault = banks
-        .get_account(validator_fees_vault_pda_from_validator(&authority.pubkey()))
+        .get_account(validator_fees_vault_pda_from_validator(
+            &authority.pubkey(),
+        ))
         .await
         .unwrap()
         .unwrap();
@@ -379,7 +438,8 @@ async fn undelegate(args: UndelegateArgs<'_>) {
     assert!(res.is_ok());
 
     // Assert the delegation_record_pda was closed
-    let delegation_record_account = args.banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_account =
+        args.banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
     // Assert the delegated metadata account pda was closed
@@ -410,7 +470,10 @@ struct FinalizeNewStateArgs<'a> {
 }
 
 async fn finalize_new_state(args: FinalizeNewStateArgs<'_>) {
-    let ix = dlp::instruction_builder::finalize(args.authority.pubkey(), args.delegated_account);
+    let ix = dlp::instruction_builder::finalize(
+        args.authority.pubkey(),
+        args.delegated_account,
+    );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&args.authority.pubkey()),
@@ -470,7 +533,8 @@ async fn commit_new_state(args: CommitNewStateArgs<'_>) {
     assert!(res.is_ok());
 
     // Assert the state commitment was created and contains the new state
-    let commit_state_pda = commit_state_pda_from_delegated_account(&args.delegated_account);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&args.delegated_account);
     let commit_state_account = args
         .banks
         .get_account(commit_state_pda)
@@ -492,15 +556,18 @@ async fn commit_new_state(args: CommitNewStateArgs<'_>) {
     );
 
     // Assert the record about the commitment exists
-    let commit_record_pda = commit_record_pda_from_delegated_account(&args.delegated_account);
+    let commit_record_pda =
+        commit_record_pda_from_delegated_account(&args.delegated_account);
     let commit_record_account = args
         .banks
         .get_account(commit_record_pda)
         .await
         .unwrap()
         .unwrap();
-    let commit_record =
-        CommitRecord::try_from_bytes_with_discriminator(&commit_record_account.data).unwrap();
+    let commit_record = CommitRecord::try_from_bytes_with_discriminator(
+        &commit_record_account.data,
+    )
+    .unwrap();
     assert_eq!(commit_record.account, args.delegated_account);
     assert_eq!(commit_record.identity, args.authority.pubkey());
     assert_eq!(commit_record.nonce, 1);
@@ -514,8 +581,10 @@ async fn commit_new_state(args: CommitNewStateArgs<'_>) {
         .unwrap()
         .unwrap();
     let delegation_metadata =
-        DelegationMetadata::try_from_bytes_with_discriminator(&delegation_metadata_account.data)
-            .unwrap();
+        DelegationMetadata::try_from_bytes_with_discriminator(
+            &delegation_metadata_account.data,
+        )
+        .unwrap();
     assert!(delegation_metadata.is_undelegatable);
 }
 
@@ -585,7 +654,8 @@ async fn setup_program_for_commit_test_env(
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&args.delegated_account),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_protocol_claim_fees.rs
+++ b/tests/test_protocol_claim_fees.rs
@@ -1,13 +1,15 @@
-use crate::fixtures::TEST_AUTHORITY;
 use dlp::pda::fees_vault_pda;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+
+use crate::fixtures::TEST_AUTHORITY;
 
 mod fixtures;
 

--- a/tests/test_top_up.rs
+++ b/tests/test_top_up.rs
@@ -1,20 +1,27 @@
-use crate::fixtures::{
-    create_delegation_metadata_data, create_delegation_record_data, TEST_AUTHORITY,
+use dlp::{
+    args::DelegateEphemeralBalanceArgs,
+    ephemeral_balance_seeds_from_payer,
+    pda::{
+        delegation_metadata_pda_from_delegated_account,
+        delegation_record_pda_from_delegated_account,
+        ephemeral_balance_pda_from_payer, fees_vault_pda,
+        validator_fees_vault_pda_from_validator,
+    },
+    state::DelegationRecord,
 };
-use dlp::args::DelegateEphemeralBalanceArgs;
-use dlp::ephemeral_balance_seeds_from_payer;
-use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    ephemeral_balance_pda_from_payer, fees_vault_pda, validator_fees_vault_pda_from_validator,
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
 };
-use dlp::state::DelegationRecord;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::{Account, ReadableAccount},
     signature::{Keypair, Signer},
     transaction::Transaction,
+};
+
+use crate::fixtures::{
+    create_delegation_metadata_data, create_delegation_record_data,
+    TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -30,12 +37,18 @@ async fn test_top_up_ephemeral_balance() {
         None,
         None,
     );
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 
     // Check account exists and it's owned by the system program
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
     let balance_account = banks
         .get_account(ephemeral_balance_pda)
         .await
@@ -53,8 +66,18 @@ async fn test_top_up_ephemeral_balance_for_pubkey() {
 
     let pubkey = Keypair::new().pubkey();
 
-    let ix = dlp::instruction_builder::top_up_ephemeral_balance(payer.pubkey(), pubkey, None, None);
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let ix = dlp::instruction_builder::top_up_ephemeral_balance(
+        payer.pubkey(),
+        pubkey,
+        None,
+        None,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 
@@ -99,7 +122,8 @@ async fn test_top_up_ephemeral_balance_and_delegate() {
     assert!(res.is_ok());
 
     // Check account exists and it's owned by the delegation program (delegated)
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
     let balance_account = banks
         .get_account(ephemeral_balance_pda)
         .await
@@ -118,8 +142,10 @@ async fn test_top_up_ephemeral_balance_and_delegate() {
         .unwrap()
         .unwrap();
     let delegation_record =
-        DelegationRecord::try_from_bytes_with_discriminator(&delegation_record_account.data)
-            .unwrap();
+        DelegationRecord::try_from_bytes_with_discriminator(
+            &delegation_record_account.data,
+        )
+        .unwrap();
     assert_eq!(delegation_record.owner, system_program::id());
 }
 
@@ -132,7 +158,12 @@ async fn test_top_up_ephemeral_balance_and_delegate_for_pubkey() {
     let pubkey = key.pubkey();
 
     // Top-up Ix
-    let ix = dlp::instruction_builder::top_up_ephemeral_balance(payer.pubkey(), pubkey, None, None);
+    let ix = dlp::instruction_builder::top_up_ephemeral_balance(
+        payer.pubkey(),
+        pubkey,
+        None,
+        None,
+    );
     // Delegate ephemeral balance Ix
     let delegate_ix = dlp::instruction_builder::delegate_ephemeral_balance(
         payer.pubkey(),
@@ -167,7 +198,8 @@ async fn test_undelegate() {
     let (banks, _, payer_alt, blockhash) = setup_program_test_env().await;
     let validator = Keypair::from_bytes(&TEST_AUTHORITY).unwrap();
 
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer_alt.pubkey(), 0);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer_alt.pubkey(), 0);
     let ephemeral_balance_owner = banks
         .get_account(ephemeral_balance_pda)
         .await
@@ -195,7 +227,8 @@ async fn test_undelegate() {
     assert!(res.is_ok());
 
     // Assert that the ephemeral balance account still exists but is now owned by the system program
-    let ephemeral_balance_account = banks.get_account(ephemeral_balance_pda).await.unwrap();
+    let ephemeral_balance_account =
+        banks.get_account(ephemeral_balance_pda).await.unwrap();
     assert!(ephemeral_balance_account.is_some());
 
     let actual_owner = *ephemeral_balance_account.unwrap().owner();
@@ -209,7 +242,8 @@ async fn test_undelegate_and_close() {
 
     let validator = Keypair::from_bytes(&TEST_AUTHORITY).unwrap();
 
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer_alt.pubkey(), 0);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer_alt.pubkey(), 0);
 
     let prev_payer_lamports = banks
         .get_account(payer_alt.pubkey())
@@ -233,7 +267,10 @@ async fn test_undelegate_and_close() {
         validator.pubkey(),
     );
 
-    let ix_close = dlp::instruction_builder::close_ephemeral_balance(payer_alt.pubkey(), 0);
+    let ix_close = dlp::instruction_builder::close_ephemeral_balance(
+        payer_alt.pubkey(),
+        0,
+    );
 
     let tx = Transaction::new_signed_with_payer(
         &[ix, ix_close],
@@ -245,7 +282,8 @@ async fn test_undelegate_and_close() {
     assert!(res.is_ok());
 
     // Assert that the ephemeral balance account is closed
-    let ephemeral_balance_account = banks.get_account(ephemeral_balance_pda).await.unwrap();
+    let ephemeral_balance_account =
+        banks.get_account(ephemeral_balance_pda).await.unwrap();
     assert!(ephemeral_balance_account.is_none());
 
     let payer_lamports = banks
@@ -325,7 +363,8 @@ async fn setup_ephemeral_balance(
     validator: &Keypair,
     payer: &Keypair,
 ) {
-    let ephemeral_balance_pda = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
+    let ephemeral_balance_pda =
+        ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
 
     // Setup the delegated account PDA
     program_test.add_account(
@@ -348,7 +387,8 @@ async fn setup_ephemeral_balance(
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -365,7 +405,8 @@ async fn setup_ephemeral_balance(
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&ephemeral_balance_pda),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_undelegate.rs
+++ b/tests/test_undelegate.rs
@@ -1,10 +1,13 @@
 use dlp::pda::{
-    commit_record_pda_from_delegated_account, commit_state_pda_from_delegated_account,
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, validator_fees_vault_pda_from_validator,
+    commit_record_pda_from_delegated_account,
+    commit_state_pda_from_delegated_account,
+    delegation_metadata_pda_from_delegated_account,
+    delegation_record_pda_from_delegated_account, fees_vault_pda,
+    validator_fees_vault_pda_from_validator,
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -13,8 +16,9 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    get_commit_record_account_data, get_delegation_metadata_data, get_delegation_record_data,
-    COMMIT_NEW_STATE_ACCOUNT_DATA, DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
+    get_commit_record_account_data, get_delegation_metadata_data,
+    get_delegation_record_data, COMMIT_NEW_STATE_ACCOUNT_DATA,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -25,15 +29,21 @@ async fn test_finalize_and_undelegate() {
     let (banks, _, authority, blockhash) = setup_program_test_env().await;
 
     // Retrieve the accounts
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
 
     // Save the new state data before undelegating
-    let new_state_before_finalize = banks.get_account(commit_state_pda).await.unwrap().unwrap();
+    let new_state_before_finalize =
+        banks.get_account(commit_state_pda).await.unwrap().unwrap();
     let new_state_data_before_finalize = new_state_before_finalize.data.clone();
 
     // Create the finalize tx
-    let ix_finalize = dlp::instruction_builder::finalize(authority.pubkey(), DELEGATED_PDA_ID);
+    let ix_finalize = dlp::instruction_builder::finalize(
+        authority.pubkey(),
+        DELEGATED_PDA_ID,
+    );
 
     // Create the undelegate tx
     let ix_undelegate = dlp::instruction_builder::undelegate(
@@ -55,20 +65,25 @@ async fn test_finalize_and_undelegate() {
     assert!(res.is_ok());
 
     // Assert the state_diff was closed
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap();
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap();
     assert!(commit_state_account.is_none());
 
     // Assert the delegation_record_pda was closed
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
     // Assert the delegated account seeds pda was closed
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_metadata_account = banks.get_account(delegation_metadata_pda).await.unwrap();
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_account =
+        banks.get_account(delegation_metadata_pda).await.unwrap();
     assert!(delegation_metadata_account.is_none());
 
     // Assert that the account owner is now set to the owner program
-    let pda_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert!(pda_account.owner.eq(&DELEGATED_PDA_OWNER_ID));
 
     // Assert the delegated account contains the data from the new state
@@ -104,11 +119,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(authority.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(authority.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -117,11 +134,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(authority.pubkey(), Some(true));
+    let delegation_metadata_data =
+        get_delegation_metadata_data(authority.pubkey(), Some(true));
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_undelegate_confined_account.rs
+++ b/tests/test_undelegate_confined_account.rs
@@ -1,8 +1,10 @@
 use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
+    delegation_metadata_pda_from_delegated_account,
+    delegation_record_pda_from_delegated_account,
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -11,8 +13,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    create_delegation_record_data, get_delegation_metadata_data, DELEGATED_PDA, DELEGATED_PDA_ID,
-    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
+    create_delegation_record_data, get_delegation_metadata_data, DELEGATED_PDA,
+    DELEGATED_PDA_ID, DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -23,7 +25,8 @@ async fn test_undelegate_confined_account() {
     let (banks, _payer, admin, blockhash) = setup_program_test_env().await;
 
     // Save the delegated account data before undelegating (should be preserved)
-    let delegated_before = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let delegated_before =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     let data_before = delegated_before.data.clone();
 
     // Submit the admin-only undelegate (confined) tx
@@ -32,21 +35,31 @@ async fn test_undelegate_confined_account() {
         DELEGATED_PDA_ID,
         DELEGATED_PDA_OWNER_ID,
     );
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin.pubkey()), &[&admin], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&admin.pubkey()),
+        &[&admin],
+        blockhash,
+    );
     let res = banks.process_transaction(tx).await;
     assert!(res.is_ok());
 
     // Assert delegation PDAs were closed
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_metadata_account = banks.get_account(delegation_metadata_pda).await.unwrap();
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_account =
+        banks.get_account(delegation_metadata_pda).await.unwrap();
     assert!(delegation_metadata_account.is_none());
 
     // Assert the delegated account is now owned by the original owner program
-    let pda_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert_eq!(pda_account.owner, DELEGATED_PDA_OWNER_ID);
 
     // Assert the delegated account data matches the pre-undelegation data
@@ -85,12 +98,16 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Delegation record PDA with authority = system program (confined) and owner = external program
-    let delegation_record_data =
-        create_delegation_record_data(system_program::id(), DELEGATED_PDA_OWNER_ID, None);
+    let delegation_record_data = create_delegation_record_data(
+        system_program::id(),
+        DELEGATED_PDA_OWNER_ID,
+        None,
+    );
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -99,11 +116,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Delegation metadata PDA (undelegatable) with seeds used by external test program
-    let delegation_metadata_data = get_delegation_metadata_data(admin.pubkey(), Some(true));
+    let delegation_metadata_data =
+        get_delegation_metadata_data(admin.pubkey(), Some(true));
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_undelegate_on_curve.rs
+++ b/tests/test_undelegate_on_curve.rs
@@ -1,9 +1,11 @@
 use dlp::pda::{
-    delegation_metadata_pda_from_delegated_account, delegation_record_pda_from_delegated_account,
-    fees_vault_pda, validator_fees_vault_pda_from_validator,
+    delegation_metadata_pda_from_delegated_account,
+    delegation_record_pda_from_delegated_account, fees_vault_pda,
+    validator_fees_vault_pda_from_validator,
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -12,8 +14,8 @@ use solana_sdk::{
 };
 
 use crate::fixtures::{
-    get_delegation_metadata_data_on_curve, get_delegation_record_on_curve_data, ON_CURVE_KEYPAIR,
-    TEST_AUTHORITY,
+    get_delegation_metadata_data_on_curve, get_delegation_record_on_curve_data,
+    ON_CURVE_KEYPAIR, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -21,11 +23,13 @@ mod fixtures;
 #[tokio::test]
 async fn test_undelegate_on_curve() {
     // Setup
-    let (banks, validator, delegated_on_curve, blockhash) = setup_program_test_env().await;
+    let (banks, validator, delegated_on_curve, blockhash) =
+        setup_program_test_env().await;
 
     // Retrieve the accounts
-    let delegation_record_pda =
-        delegation_record_pda_from_delegated_account(&delegated_on_curve.pubkey());
+    let delegation_record_pda = delegation_record_pda_from_delegated_account(
+        &delegated_on_curve.pubkey(),
+    );
 
     // Submit the undelegate tx
     let ix = dlp::instruction_builder::undelegate(
@@ -45,13 +49,17 @@ async fn test_undelegate_on_curve() {
     assert!(res.is_ok());
 
     // Assert the delegation_record_pda was closed
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
     // Assert the delegated metadata account pda was closed
     let delegation_metadata_pda =
-        delegation_metadata_pda_from_delegated_account(&delegated_on_curve.pubkey());
-    let delegation_metadata_account = banks.get_account(delegation_metadata_pda).await.unwrap();
+        delegation_metadata_pda_from_delegated_account(
+            &delegated_on_curve.pubkey(),
+        );
+    let delegation_metadata_account =
+        banks.get_account(delegation_metadata_pda).await.unwrap();
     assert!(delegation_metadata_account.is_none());
 
     // Assert that the account owner is now set to the system program
@@ -82,8 +90,10 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data =
-        get_delegation_record_on_curve_data(payer_alt.pubkey(), Some(LAMPORTS_PER_SOL));
+    let delegation_record_data = get_delegation_record_on_curve_data(
+        payer_alt.pubkey(),
+        Some(LAMPORTS_PER_SOL),
+    );
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&payer_alt.pubkey()),
         Account {

--- a/tests/test_undelegate_without_commit.rs
+++ b/tests/test_undelegate_without_commit.rs
@@ -1,10 +1,12 @@
 use dlp::pda::{
-    commit_state_pda_from_delegated_account, delegation_metadata_pda_from_delegated_account,
+    commit_state_pda_from_delegated_account,
+    delegation_metadata_pda_from_delegated_account,
     delegation_record_pda_from_delegated_account, fees_vault_pda,
     validator_fees_vault_pda_from_validator,
 };
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
@@ -25,13 +27,16 @@ async fn test_undelegate_without_commit() {
     let (banks, _, validator, blockhash) = setup_program_test_env().await;
 
     // Retrieve the accounts
-    let delegation_record_pda = delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let commit_state_pda = commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_record_pda =
+        delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let commit_state_pda =
+        commit_state_pda_from_delegated_account(&DELEGATED_PDA_ID);
 
     // Save the new state data before undelegating
     let delegated_pda_state_before_undelegation =
         banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
-    let new_state_data_before_finalize = delegated_pda_state_before_undelegation.data.clone();
+    let new_state_data_before_finalize =
+        delegated_pda_state_before_undelegation.data.clone();
 
     // Submit the undelegate tx
     let ix = dlp::instruction_builder::undelegate(
@@ -51,24 +56,30 @@ async fn test_undelegate_without_commit() {
     assert!(res.is_ok());
 
     // Assert the state_diff was closed
-    let commit_state_account = banks.get_account(commit_state_pda).await.unwrap();
+    let commit_state_account =
+        banks.get_account(commit_state_pda).await.unwrap();
     assert!(commit_state_account.is_none());
 
     // Assert the delegation_record_pda was closed
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
     // Assert the delegation_record_pda was closed
-    let delegation_record_account = banks.get_account(delegation_record_pda).await.unwrap();
+    let delegation_record_account =
+        banks.get_account(delegation_record_pda).await.unwrap();
     assert!(delegation_record_account.is_none());
 
     // Assert the delegated account seeds pda was closed
-    let delegation_metadata_pda = delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
-    let delegation_metadata_account = banks.get_account(delegation_metadata_pda).await.unwrap();
+    let delegation_metadata_pda =
+        delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID);
+    let delegation_metadata_account =
+        banks.get_account(delegation_metadata_pda).await.unwrap();
     assert!(delegation_metadata_account.is_none());
 
     // Assert that the account owner is now set to the owner program
-    let pda_account = banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
+    let pda_account =
+        banks.get_account(DELEGATED_PDA_ID).await.unwrap().unwrap();
     assert!(pda_account.owner.eq(&DELEGATED_PDA_OWNER_ID));
 
     // Assert the delegated account contains the data from the new state
@@ -104,11 +115,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated record PDA
-    let delegation_record_data = get_delegation_record_data(validator.pubkey(), None);
+    let delegation_record_data =
+        get_delegation_record_data(validator.pubkey(), None);
     program_test.add_account(
         delegation_record_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_record_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_record_data.len()),
             data: delegation_record_data,
             owner: dlp::id(),
             executable: false,
@@ -117,11 +130,13 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
     );
 
     // Setup the delegated account metadata PDA
-    let delegation_metadata_data = get_delegation_metadata_data(validator.pubkey(), Some(true));
+    let delegation_metadata_data =
+        get_delegation_metadata_data(validator.pubkey(), Some(true));
     program_test.add_account(
         delegation_metadata_pda_from_delegated_account(&DELEGATED_PDA_ID),
         Account {
-            lamports: Rent::default().minimum_balance(delegation_metadata_data.len()),
+            lamports: Rent::default()
+                .minimum_balance(delegation_metadata_data.len()),
             data: delegation_metadata_data,
             owner: dlp::id(),
             executable: false,

--- a/tests/test_validator_claim_fees.rs
+++ b/tests/test_validator_claim_fees.rs
@@ -1,13 +1,18 @@
-use crate::fixtures::TEST_AUTHORITY;
-use dlp::consts::PROTOCOL_FEES_PERCENTAGE;
-use dlp::pda::{fees_vault_pda, validator_fees_vault_pda_from_validator};
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use dlp::{
+    consts::PROTOCOL_FEES_PERCENTAGE,
+    pda::{fees_vault_pda, validator_fees_vault_pda_from_validator},
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, system_program,
+};
 use solana_program_test::{BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+
+use crate::fixtures::TEST_AUTHORITY;
 
 mod fixtures;
 
@@ -24,7 +29,8 @@ async fn test_validator_claim_fees() {
         .unwrap()
         .lamports;
 
-    let validator_fees_vault_pda = validator_fees_vault_pda_from_validator(&validator.pubkey());
+    let validator_fees_vault_pda =
+        validator_fees_vault_pda_from_validator(&validator.pubkey());
     let validator_fees_vault_init_lamports = banks
         .get_account(validator_fees_vault_pda)
         .await
@@ -41,8 +47,10 @@ async fn test_validator_claim_fees() {
 
     // Submit the withdrawal tx
     let withdrawal_amount = 100000;
-    let ix =
-        dlp::instruction_builder::validator_claim_fees(validator.pubkey(), Some(withdrawal_amount));
+    let ix = dlp::instruction_builder::validator_claim_fees(
+        validator.pubkey(),
+        Some(withdrawal_amount),
+    );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -53,7 +61,8 @@ async fn test_validator_claim_fees() {
     assert!(res.is_ok());
 
     // Assert the validator fees vault now has less lamports
-    let validator_fees_vault_account = banks.get_account(validator_fees_vault_pda).await.unwrap();
+    let validator_fees_vault_account =
+        banks.get_account(validator_fees_vault_pda).await.unwrap();
     assert!(validator_fees_vault_account.is_some());
     assert_eq!(
         validator_fees_vault_account.unwrap().lamports,
@@ -61,7 +70,8 @@ async fn test_validator_claim_fees() {
     );
 
     // Assert the fees vault now has prev lamports + fees
-    let protocol_fees = (withdrawal_amount * u64::from(PROTOCOL_FEES_PERCENTAGE)) / 100;
+    let protocol_fees =
+        (withdrawal_amount * u64::from(PROTOCOL_FEES_PERCENTAGE)) / 100;
     let fees_vault_account = banks.get_account(fees_vault_pda).await.unwrap();
     assert!(fees_vault_account.is_some());
     assert_eq!(
@@ -70,7 +80,8 @@ async fn test_validator_claim_fees() {
     );
 
     let claim_amount = withdrawal_amount.saturating_sub(protocol_fees);
-    let validator_account = banks.get_account(validator.pubkey()).await.unwrap();
+    let validator_account =
+        banks.get_account(validator.pubkey()).await.unwrap();
     assert_eq!(
         validator_account.unwrap().lamports,
         validator_init_lamports + claim_amount

--- a/tests/test_whitelist_validator_for_program.rs
+++ b/tests/test_whitelist_validator_for_program.rs
@@ -1,14 +1,15 @@
-use crate::fixtures::{DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY};
-use dlp::pda::program_config_from_program_id;
-use dlp::state::ProgramConfig;
-use solana_program::rent::Rent;
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL, system_program};
+use dlp::{pda::program_config_from_program_id, state::ProgramConfig};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, rent::Rent, system_program,
+};
 use solana_program_test::{read_file, BanksClient, ProgramTest};
 use solana_sdk::{
     account::Account,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+
+use crate::fixtures::{DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY};
 
 mod fixtures;
 


### PR DESCRIPTION
This PR primary adds `rustfmt.toml` and a `Makefile`. 

Other changes are due to `make fmt`. That's it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Makefile and code formatting configuration for build and development tooling.

* **Refactor**
  * Standardized code formatting and import organization across the codebase for improved maintainability.
  * Refined function signatures and structural organization for consistency.

* **Deprecation**
  * Marked `call_handler` function as deprecated; use `call_handler_v2` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->