### PR TITLE
fix: many broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ Delegation module for https://arxiv.org/pdf/2311.02650.pdf
 
 ## Public Api
 
-- [`Instruction Builders`](src/instruction_builder/*.rs) – utilities to generate Instructions.
-- [`Args`](src/args/*.rs) – Instructions arguments structures.
+- [`Instruction Builders`](src/instruction_builder/) – utilities to generate Instructions.
+- [`Args`](src/args/) – Instructions arguments structures.
 - [`Consts`](src/consts.rs) – Program constants.
 - [`Errors`](src/error.rs) – Custom program errors.
 
 ## Program
 
 - [`Entrypoint`](src/lib.rs) – The program entrypoint.
-- [`Processors`](src/processors/) – Instruction implementations.
+- [`Processors`](src/processor/) – Instruction implementations.
 
 ## Important Instructions
 
-- [`Delegate`](src/processor/delegate.rs) - Delegate an account
-- [`CommitState`](src/processor/commit_state.rs) – Commit a new state
-- [`Finalize`](src/processor/finalize.rs) – Finalize a new state
-- [`Undelegate`](src/processor/undelegate.rs) – Undelegate an account
+- [`Delegate`](src/processor/fast/delegate.rs) - Delegate an account
+- [`CommitState`](src/processor/fast/commit_state.rs) – Commit a new state
+- [`Finalize`](src/processor/fast/finalize.rs) – Finalize a new state
+- [`Undelegate`](src/processor/fast/undelegate.rs) – Undelegate an account
 
 ## Tests
 


### PR DESCRIPTION
## Summary

The [README](https://github.com/evshank/delegation-program/blob/main/README.md#public-api) at the beginning contained many broken links, which I fixed:

1. Sector: `Public Api` 
Broken links: 2 out of 4
Reason: An extra `/rs` was added, making the links invalid.

2. Sector: `Program`
Broken links: 1 out of 2
Reason: There was an extra `s` in the word `processor`.

5. Sector: `Important Instructions`
Broken links: 4 out of 4
Reason: All files were located in the `src/processor/fast` folder, but the path was specified as `src/processor/`. 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API module references and export paths in documentation.

* **Refactor**
  * Reorganized module structure and directory organization for improved code layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->