### PR TITLE
Fix missing yarn dependency in test job CI workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config build-essential libudev-dev
-          npm install --global yarn
 
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
@@ -108,6 +107,7 @@ jobs:
         run: |
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cd tests/integration 
+          npm install --global yarn
           cargo install --locked --version ${{ env.anchor_version }} anchor-cli
           npm install
           anchor test


### PR DESCRIPTION
Fixes an implicit dependency on a globally installed `yarn` binary in the CI workflow.

Previously, `yarn` was installed in the `install` job, but integration tests were executed in a separate `test` job. Since GitHub Actions jobs run in isolated environments, the `yarn` installation was not available during test execution. As a result, the CI relied on `yarn` being preinstalled in the runner image, which is not guaranteed and introduces non-deterministic behavior.

The fix ensures that `yarn` is installed directly in the `test` job before running `anchor test`, making the dependency explicit and the workflow deterministic.

Additionally, the redundant `yarn` installation has been removed from the `install` job, since it is not used there.

This change improves CI reliability by eliminating hidden environment dependencies and aligning the workflow with best practices, where each job explicitly declares and installs its required runtime dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to optimize dependency installation timing during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->