### PR TITLE
fix: broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Delegation module for https://arxiv.org/pdf/2311.02650.pdf
 
 ## Public Api
 
-- [`Instruction Builders`](src/instruction_builder/) – utilities to generate Instructions.
-- [`Args`](src/args/) – Instructions arguments structures.
-- [`Consts`](src/consts.rs) – Program constants.
-- [`Errors`](src/error.rs) – Custom program errors.
+- [`Instruction Builders`](dlp-api/src/instruction_builder/) – utilities to generate Instructions.
+- [`Args`](dlp-api/src/args/) – Instructions arguments structures.
+- [`Consts`](dlp-api/src/consts.rs) – Program constants.
+- [`Errors`](dlp-api/src/error.rs) – Custom program errors.
 
 ## Program
 


### PR DESCRIPTION
## Problem

In the README:
- Instruction-builder
- Args
- Consts
- Error

the paths were incorrect: `src/...` etc.

## Solution

Corrected to the correct path: `dlp-api/src/...` etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reflect updated module path references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->