### PR TITLE
fix(program): enforce program config whitelist on `commit_finalize` instructions

### DIFF
--- a/src/processor/fast/commit_finalize.rs
+++ b/src/processor/fast/commit_finalize.rs
@@ -23,7 +23,8 @@ use crate::{
 /// 2: `[]`         the delegation record
 /// 3: `[writable]` the delegation metadata
 /// 4: `[]`         the validator fees vault
-/// 5: `[]`         system program
+/// 5: `[]`         the program config account
+/// 6: `[]`         system program
 ///
 /// Instruction Data: CommitFinalizeArgsWithBuffer
 ///
@@ -38,8 +39,9 @@ pub fn process_commit_finalize(
         delegation_record_account,
         delegation_metadata_account,
         validator_fees_vault,
+        program_config_account,
         _system_program,
-    ] = require_n_accounts!(accounts, 6);
+    ] = require_n_accounts!(accounts, 7);
 
     let args = CommitFinalizeArgsWithBuffer::from_bytes(data)?;
 
@@ -61,7 +63,9 @@ pub fn process_commit_finalize(
         delegation_record_account,
         delegation_metadata_account,
         validator_fees_vault,
+        program_config_account,
     };
 
     process_commit_finalize_internal(commit_args)
 }
+

--- a/src/processor/fast/commit_finalize_from_buffer.rs
+++ b/src/processor/fast/commit_finalize_from_buffer.rs
@@ -13,17 +13,18 @@ use crate::{
     require_n_accounts, DiffSet,
 };
 
-/// Commit a new state of a delegated PDA
+/// Commit a new state, or a diff, from a buffer account directly to the delegated account.
 ///
 /// Accounts:
 ///
 /// 0: `[signer]`   the validator requesting the commit
 /// 1: `[]`         the delegated account
-/// 2: `[writable]` the PDA storing the new state
-/// 3: `[writable]` the PDA storing the commit record
-/// 4: `[]`         the delegation record
-/// 5: `[writable]` the delegation metadata
-/// 6: `[]`         the validator fees vault
+/// 2: `[]`         the delegation record
+/// 3: `[writable]` the delegation metadata
+/// 4: `[]`         the buffer account holding full state or diff bytes
+/// 5: `[]`         the validator fees vault
+/// 6: `[]`         the program config account
+/// 7: `[]`         system program
 ///
 /// Instruction Data: CommitFinalizeArgs
 ///
@@ -32,17 +33,10 @@ use crate::{
 /// - delegation record is initialized
 /// - delegation metadata is initialized
 /// - validator fees vault is initialized
-/// - program config is initialized
-/// - commit state is uninitialized
-/// - commit record is uninitialized
+/// - if a program config PDA exists for the delegated account's owner program, the validator
+///   must be whitelisted in that config (same rules as [`super::process_commit_state`])
 /// - delegated account holds at least the lamports indicated in the delegation record
-/// - account was not committed at a later slot
-///
-/// Steps:
-/// 1. Check that the pda is delegated
-/// 2. Init a new PDA to store the new state
-/// 3. Copy the new state to the new PDA
-/// 4. Init a new PDA to store the record of the new state commitment
+
 pub fn process_commit_finalize_from_buffer(
     _program_id: &Address,
     accounts: &[AccountView],
@@ -55,8 +49,9 @@ pub fn process_commit_finalize_from_buffer(
         delegation_metadata_account,
         data_account, // full bytes or diff 
         validator_fees_vault,
+        program_config_account,
         _system_program,
-    ] = require_n_accounts!(accounts, 7);
+    ] = require_n_accounts!(accounts, 8);
 
     let args = CommitFinalizeArgs::try_view_from(data)?;
 
@@ -79,6 +74,7 @@ pub fn process_commit_finalize_from_buffer(
         delegation_record_account,
         delegation_metadata_account,
         validator_fees_vault,
+        program_config_account,
     };
 
     process_commit_finalize_internal(commit_args)

--- a/src/processor/fast/internal/commit_finalize_internal.rs
+++ b/src/processor/fast/internal/commit_finalize_internal.rs
@@ -1,8 +1,4 @@
-use pinocchio::{
-    address::{address_eq, PDA_MARKER},
-    error::ProgramError,
-    AccountView, Address,
-};
+use pinocchio::{address::PDA_MARKER, error::ProgramError, AccountView, Address};
 use pinocchio_log::log;
 
 use crate::{
@@ -11,10 +7,11 @@ use crate::{
     error::DlpError,
     pda,
     pod_view::PodView,
-    processor::fast::NewState,
+    processor::fast::{to_pinocchio_program_error, NewState},
     require, require_eq, require_eq_keys, require_ge,
     require_initialized_pda_fast, require_owned_by, require_signer,
-    state::{DelegationMetadataFast, DelegationRecord},
+    requires::require_program_config,
+    state::{DelegationMetadataFast, DelegationRecord, ProgramConfig},
 };
 
 /// Arguments for the commit state internal function
@@ -28,6 +25,7 @@ pub(crate) struct CommitFinalizeInternalArgs<'a> {
     pub(crate) delegation_record_account: &'a AccountView,
     pub(crate) delegation_metadata_account: &'a AccountView,
     pub(crate) validator_fees_vault: &'a AccountView,
+    pub(crate) program_config_account: &'a AccountView,
 }
 
 /// Commit a new state of a delegated Pda
@@ -108,6 +106,28 @@ pub(crate) fn process_commit_finalize_internal(
         delegation_record.lamports,
         DlpError::InvalidDelegatedState
     );
+
+    let has_program_config = require_program_config(
+        args.program_config_account,
+        &Address::from(delegation_record.owner.to_bytes()),
+        false,
+    )?;
+    if has_program_config {
+        let program_config_data = args.program_config_account.try_borrow()?;
+
+        let program_config = ProgramConfig::try_from_bytes_with_discriminator(
+            &program_config_data,
+        )
+        .map_err(to_pinocchio_program_error)?;
+        if !program_config
+            .approved_validators
+            .contains(&args.validator.address().to_bytes().into())
+        {
+            log!("validator is not whitelisted in the program config: ");
+            args.validator.address().log();
+            return Err(DlpError::InvalidWhitelistProgramConfig.into());
+        }
+    }
 
     // if args.commit_record_lamports > delegation_record.lamports {
     //     system::Transfer {


### PR DESCRIPTION
Added the `program_config` account and enforced the same whitelist validation as in `commit_state` for both `commit_finalize` and `commit_finalize_from_buffer`. Updated the number and order of accounts accordingly.

After merging this PR, older clients sending fewer accounts will fail on-chain - this is expected until the SDK is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added program configuration validation for commit finalization operations
  * Validators must now be approved in program configuration whitelist to execute commits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->