### PR TITLE
fix(api): add `program_config` account to `commit_finalize` builders

### DIFF
--- a/dlp-api/src/instruction_builder/commit_finalize.rs
+++ b/dlp-api/src/instruction_builder/commit_finalize.rs
@@ -3,6 +3,7 @@ use dlp::{
     delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account,
     discriminator::DlpDiscriminator,
+    pda::program_config_from_program_id,
     pod_view::PodView,
     total_size_budget, validator_fees_vault_seeds_from_validator,
     AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
@@ -24,6 +25,7 @@ pub struct CommitPDAs {
 pub fn commit_finalize(
     validator: Pubkey,
     delegated_account: Pubkey,
+    delegated_account_owner: Pubkey,
     args: &mut CommitFinalizeArgs,
     state_or_diff: &[u8],
 ) -> (Instruction, CommitPDAs) {
@@ -42,6 +44,8 @@ pub fn commit_finalize(
         &dlp::id(),
     );
 
+    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+
     // save the bumps in the args
     args.bumps = CommitBumps {
         delegation_record: delegation_record.1,
@@ -58,6 +62,7 @@ pub fn commit_finalize(
                 AccountMeta::new_readonly(delegation_record.0, false),
                 AccountMeta::new(delegation_metadata.0, false),
                 AccountMeta::new_readonly(validator_fees_vault.0, false),
+                AccountMeta::new_readonly(program_config_pda, false),
                 AccountMeta::new_readonly(system_program::id(), false),
             ],
             data: [
@@ -88,6 +93,7 @@ pub fn commit_finalize_size_budget(delegated_account: AccountSizeClass) -> u32 {
         AccountSizeClass::Tiny, // delegation_record_pda
         AccountSizeClass::Tiny, // delegation_metadata_pda
         AccountSizeClass::Tiny, // validator_fees_vault_pda
+        AccountSizeClass::Tiny, // program_config_pda
         AccountSizeClass::Tiny, // system_program
     ])
 }

--- a/dlp-api/src/instruction_builder/commit_finalize_from_buffer.rs
+++ b/dlp-api/src/instruction_builder/commit_finalize_from_buffer.rs
@@ -3,6 +3,7 @@ use dlp::{
     delegation_metadata_seeds_from_delegated_account,
     delegation_record_seeds_from_delegated_account,
     discriminator::DlpDiscriminator,
+    pda::program_config_from_program_id,
     pod_view::PodView,
     total_size_budget, validator_fees_vault_seeds_from_validator,
     AccountSizeClass, DLP_PROGRAM_DATA_SIZE_CLASS,
@@ -13,11 +14,12 @@ use solana_program::{
     system_program,
 };
 
-/// Builds a commit state from buffer instruction.
-/// See [dlp::processor::process_commit_diff_from_buffer] for docs.
+/// Builds a commit finalize from buffer instruction.
+/// See [dlp::processor::process_commit_finalize_from_buffer] for docs.
 pub fn commit_finalize_from_buffer(
     validator: Pubkey,
     delegated_account: Pubkey,
+    delegated_account_owner: Pubkey,
     data_buffer: Pubkey,
     commit_args: &mut CommitFinalizeArgs,
 ) -> (Instruction, super::CommitPDAs) {
@@ -36,6 +38,8 @@ pub fn commit_finalize_from_buffer(
         &dlp::id(),
     );
 
+    let program_config_pda = program_config_from_program_id(&delegated_account_owner);
+
     // save the bumps in the args
     commit_args.bumps = CommitBumps {
         delegation_record: delegation_record.1,
@@ -53,6 +57,7 @@ pub fn commit_finalize_from_buffer(
                 AccountMeta::new(delegation_metadata.0, false),
                 AccountMeta::new_readonly(data_buffer, false),
                 AccountMeta::new_readonly(validator_fees_vault.0, false),
+                AccountMeta::new_readonly(program_config_pda, false),
                 AccountMeta::new_readonly(system_program::id(), false),
             ],
             data: [
@@ -70,7 +75,7 @@ pub fn commit_finalize_from_buffer(
 }
 
 ///
-/// Returns accounts-data-size budget for commit_diff_from_buffer instruction.
+/// Returns accounts-data-size budget for commit_finalize_from_buffer instruction.
 ///
 /// This value can be used with ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit
 ///


### PR DESCRIPTION
Added the `delegated_account_owner` parameter and included the program config PDA in the accounts metadata before the system program, this is a breaking change for builder calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Commit finalization operations now require an additional account configuration parameter.
  * Configuration data is automatically derived and included in commit processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->