### PR TITLE
fix(tests): update `commit_finalize` tests with `delegated_account_owner`

### DIFF
--- a/tests/test_commit_finalize.rs
+++ b/tests/test_commit_finalize.rs
@@ -22,7 +22,7 @@ use solana_sdk::{
 
 use crate::fixtures::{
     get_delegation_metadata_data, get_delegation_record_data, DELEGATED_PDA_ID,
-    TEST_AUTHORITY,
+    DELEGATED_PDA_OWNER_ID, TEST_AUTHORITY,
 };
 
 mod fixtures;
@@ -52,6 +52,7 @@ async fn run_test_commit_finalize(
     let (ix, pdas) = dlp_api::instruction_builder::commit_finalize(
         authority.pubkey(),
         DELEGATED_PDA_ID,
+        DELEGATED_PDA_OWNER_ID,
         &mut CommitFinalizeArgs {
             commit_id: 1,
             allow_undelegation: true.into(),
@@ -124,6 +125,7 @@ async fn test_commit_finalize_out_of_order() {
     let (ix, _pdas) = dlp_api::instruction_builder::commit_finalize(
         authority.pubkey(),
         DELEGATED_PDA_ID,
+        DELEGATED_PDA_OWNER_ID,
         &mut CommitFinalizeArgs {
             commit_id: 2, // this is the min value which will cause NonceOutOfOrder
             allow_undelegation: true.into(),


### PR DESCRIPTION
Updated `commit_finalize` tests to include the new `delegated_account_owner parameter`. All instruction builders in tests now pass the account owner, reflecting the addition of the program config PDA in account metadata. This ensures tests remain compatible with the updated API and correctly validate `commit_finalize` behavior.