### PR TITLE
fix: use correct PDA in "Initializes another counter" test

### DIFF
--- a/tests/integration/tests/test-delegation.ts
+++ b/tests/integration/tests/test-delegation.ts
@@ -12,6 +12,7 @@ import { ON_CURVE_ACCOUNT } from "./fixtures/consts";
 import { assert } from "chai";
 
 const SEED_TEST_PDA = "test-pda";
+const SEED_TEST_PDA_OTHER = "test-pda-other";
 const BPF_LOADER = new web3.PublicKey(
   "BPFLoaderUpgradeab1e11111111111111111111111"
 );
@@ -26,6 +27,10 @@ describe("TestDelegation", () => {
 
   const [pda] = anchor.web3.PublicKey.findProgramAddressSync(
     [Buffer.from(SEED_TEST_PDA)],
+    testDelegation.programId
+  );
+  const [pdaOther] = anchor.web3.PublicKey.findProgramAddressSync(
+    [Buffer.from(SEED_TEST_PDA_OTHER)],
     testDelegation.programId
   );
   const payer = provider.wallet.publicKey;
@@ -88,7 +93,7 @@ describe("TestDelegation", () => {
 
   it("Initializes another counter", async () => {
     // Check if the counter is initialized
-    const counterAccountInfo = await provider.connection.getAccountInfo(pda);
+    const counterAccountInfo = await provider.connection.getAccountInfo(pdaOther);
     if (counterAccountInfo === null) {
       const tx = await testDelegation.methods
         .initializeOther()
@@ -96,10 +101,10 @@ describe("TestDelegation", () => {
           user: provider.wallet.publicKey,
         })
         .rpc({ skipPreflight: true });
-      console.log("Init Pda Tx: ", tx);
+      console.log("Init Other Pda Tx: ", tx);
     }
-    const counterAccount = await testDelegation.account.counter.fetch(pda);
-    console.log("Counter: ", counterAccount.count.toString());
+    const counterAccount = await testDelegation.account.counter.fetch(pdaOther);
+    console.log("Counter (other): ", counterAccount.count.toString());
   });
 
   it("Increase the counter", async () => {


### PR DESCRIPTION
## Summary

Fixes incorrect PDA usage in the "Initializes another counter" test.

## Problem

The test calls `initializeOther()`, which initializes a counter using a different seed (`TEST_PDA_SEED_OTHER`). However, the test was reading and validating the original PDA derived from `TEST_PDA_SEED`.

As a result, the test could pass even if `initializeOther()` was broken, since it did not actually verify the correct account.

## Solution

- Added a second PDA (`pdaOther`) derived from `TEST_PDA_SEED_OTHER`
- Updated the test to use `pdaOther` for account checks and state validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended the delegation test suite to validate multiple account scenarios and comprehensive operational workflows
  * Strengthened account initialization and state consistency verification across delegation test cases
  * Improved test diagnostics with enhanced logging output and console visibility for better debugging
  * Added comprehensive validation checks for account existence and complete lifecycle management verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->