### PR TITLE
Fix unsafe balance calculation

### DIFF
--- a/src/processor/validator_claim_fees.rs
+++ b/src/processor/validator_claim_fees.rs
@@ -49,18 +49,20 @@ pub fn process_validator_claim_fees(
         true,
     )?;
 
-    // Calculate the amount to transfer
+    // Lamports that can be claimed without dropping the vault below rent-exempt minimum
     let min_rent = Rent::default().minimum_balance(8);
-    let amount = args
-        .amount
-        .unwrap_or(validator_fees_vault.lamports() - min_rent);
+    let available = validator_fees_vault
+        .lamports()
+        .checked_sub(min_rent)
+        .ok_or(ProgramError::InsufficientFunds)?;
 
-    // Ensure vault has enough lamports
-    if validator_fees_vault.lamports() - min_rent < amount {
+    let amount = args.amount.unwrap_or(available);
+
+    if amount > available {
         msg!(
             "Vault ({}) has insufficient funds: {} < {}",
             validator_fees_vault.key,
-            validator_fees_vault.lamports() - min_rent,
+            available,
             amount
         );
         return Err(ProgramError::InsufficientFunds);


### PR DESCRIPTION
## Problem

Improved the balance validation logic in `process_validator_claim_fees` to safely handle rent-exempt constraints.

Previously, the code performed subtraction (`lamports - min_rent`) before validating that the vault actually held enough lamports, which could lead to fragile behavior when the vault was already below the rent-exempt threshold.

## Solution

This change introduces a safe calculation using `checked_sub`, returning `InsufficientFunds` if the vault cannot cover the rent reserve. The resulting `available` balance is then consistently used for both default amount selection and validation.

This makes the logic more robust, explicit, and safe for edge cases involving underfunded vaults.


## Before & After Screenshots

_Insert screenshots of example code output_

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]


## Other changes (e.g. bug fixes, small refactors)


## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validator fee claim validation to more accurately compute available claimable funds while respecting system reserve minimums
  * Strengthened fund availability checks to reliably prevent over-claiming scenarios
  * Improved error reporting with clear information about available amounts when claims cannot be processed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->