### PR TITLE
fix: validate decrypted PostDelegationActions enforcing signers requirement

### DIFF
--- a/dlp-api/src/args/delegate_with_actions.rs
+++ b/dlp-api/src/args/delegate_with_actions.rs
@@ -12,6 +12,37 @@ pub struct DelegateWithActionsArgs {
     pub actions: PostDelegationActions,
 }
 
+///
+/// This struct is used both as instruction args and as persisted state: it is received as
+/// instruction data and then stored in the delegation-record account immediately after
+/// DelegationRecord.
+///
+/// In the basic form, PostDelegationActions is constructed from Vec<Instruction>. In that case,
+/// both inserted_signers and inserted_non_signers are zero, and the pubkey indices used by
+/// compact::AccountMeta are computed from this imagined pubkey list:
+///
+///   [signers.., non_signers..]
+///
+/// That is, the first non-signer pubkey index is signers.len().
+///
+/// In the advanced form, an existing PostDelegationActions value (usually provided by an off-chain
+/// client) is combined with Vec<Instruction> (usually constructed on-chain) to produce a merged
+/// PostDelegationActions via ClearTextWithInsertable::cleartext_with_insertable, which allows the
+/// existing actions to be inserted at a specific instruction index. In this case, both inserted_signers
+/// and inserted_non_signers may be non-zero, and the imagined pubkey list takes this form:
+///
+///   [old_signers.., old_non_signers.., new_signers.., new_non_signers..]
+///
+/// That is, the first "new signer" comes after the old keys (old_signers + old_non_signers). Also,
+/// the `signers` field is created from:
+///
+///  [old_signers.., new_signers..]
+///
+/// and `non-signers` field is created from:
+///
+///  [old_non_signers.., new_non_signers..]
+///
+///
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PostDelegationActions {
     pub inserted_signers: u8,

--- a/dlp-api/src/decrypt.rs
+++ b/dlp-api/src/decrypt.rs
@@ -17,16 +17,33 @@ use crate::encryption::{self, EncryptionError, KEY_LEN};
 pub enum DecryptError {
     #[error(transparent)]
     DecryptFailed(#[from] EncryptionError),
+
     #[error("invalid decrypted pubkey length: {0}")]
     InvalidPubkeyLength(usize),
+
     #[error("invalid decrypted compact account meta length: {0}")]
     InvalidAccountMetaLength(usize),
+
     #[error("invalid decrypted compact account meta value: {0}")]
     InvalidAccountMetaValue(u8),
+
     #[error("invalid program_id index {index} for pubkey table len {len}")]
     InvalidProgramIdIndex { index: u8, len: usize },
+
     #[error("invalid account index {index} for pubkey table len {len}")]
     InvalidAccountIndex { index: u8, len: usize },
+
+    #[error("invalid inserted signer count {inserted} for signers len {len}")]
+    InvalidInsertedSignerCount { inserted: u8, len: usize },
+
+    #[error("invalid inserted non-signer count {inserted} for non-signers len {len}")]
+    InvalidInsertedNonSignerCount { inserted: u8, len: usize },
+
+    #[error("non-signer (index {index}) cannot be used as signer (max_index is {max_signer_index})")]
+    NonSignerCannotBeSigner {
+        index: usize,
+        max_signer_index: usize,
+    },
 }
 
 pub trait Decrypt: Sized {
@@ -133,22 +150,62 @@ impl Decrypt for MaybeEncryptedIxData {
 impl Decrypt for PostDelegationActions {
     type Output = Vec<Instruction>;
 
+    /// This function decrypts PostDelegationActions as well as
+    /// validates it, matching the expected signers with the AccountMetas.
     fn decrypt(
         self,
         recipient_x25519_pubkey: &[u8; KEY_LEN],
         recipient_x25519_secret: &[u8; KEY_LEN],
     ) -> Result<Self::Output, DecryptError> {
         let actions = self;
+        let inserted_signers = actions.inserted_signers as usize;
+        let inserted_non_signers = actions.inserted_non_signers as usize;
+        let signers_count = actions.signers.len();
+        let non_signers_count = actions.non_signers.len();
 
+        if inserted_signers > signers_count {
+            return Err(DecryptError::InvalidInsertedSignerCount {
+                inserted: actions.inserted_signers,
+                len: signers_count,
+            });
+        }
+        if inserted_non_signers > non_signers_count {
+            return Err(DecryptError::InvalidInsertedNonSignerCount {
+                inserted: actions.inserted_non_signers,
+                len: non_signers_count,
+            });
+        }
+
+        // Rebuild the lookup table in the same order used during compact
+        // index assignment (see compact module):
+        // [old signers][old non-signers][new signers][new non-signers]
         let pubkeys = {
-            let mut pubkeys = actions.signers;
-            for non_signer in actions.non_signers {
-                pubkeys.push(non_signer.decrypt(
-                    recipient_x25519_pubkey,
-                    recipient_x25519_secret,
-                )?);
-            }
-            pubkeys
+            let mut old_signers = actions.signers;
+            let new_signers = old_signers.split_off(inserted_signers);
+
+            let mut old_non_signers = actions
+                .non_signers
+                .iter()
+                .map(|non_signer| {
+                    Ok(non_signer.clone().decrypt(
+                        recipient_x25519_pubkey,
+                        recipient_x25519_secret,
+                    )?)
+                })
+                .collect::<Result<Vec<_>, DecryptError>>()?;
+
+            let new_non_signers =
+                old_non_signers.split_off(inserted_non_signers);
+
+            [old_signers, old_non_signers, new_signers, new_non_signers]
+                .concat()
+        };
+        let inserted_total = inserted_signers + inserted_non_signers;
+        let new_signers_count = signers_count - inserted_signers;
+        let is_signer_idx = |idx: usize| {
+            idx < inserted_signers
+                || (idx >= inserted_total
+                    && idx < (inserted_total + new_signers_count))
         };
 
         let instructions = actions
@@ -173,14 +230,25 @@ impl Decrypt for PostDelegationActions {
                                 recipient_x25519_pubkey,
                                 recipient_x25519_secret,
                             )?;
+                            let idx = compact_meta.key() as usize;
+
+                            if compact_meta.is_signer() && !is_signer_idx(idx) {
+                                return Err(
+                                    DecryptError::NonSignerCannotBeSigner {
+                                        index: idx,
+                                        max_signer_index: signers_count
+                                            .saturating_sub(1),
+                                    },
+                                );
+                            }
+
                             let account_pubkey = pubkeys
-                                .get(compact_meta.key() as usize)
+                                .get(idx)
                                 .copied()
                                 .ok_or(DecryptError::InvalidAccountIndex {
                                     index: compact_meta.key(),
                                     len: pubkeys.len(),
                                 })?;
-
                             Ok(AccountMeta {
                                 pubkey: account_pubkey.into(),
                                 is_signer: compact_meta.is_signer(),

--- a/dlp-api/src/decrypt.rs
+++ b/dlp-api/src/decrypt.rs
@@ -39,10 +39,11 @@ pub enum DecryptError {
     #[error("invalid inserted non-signer count {inserted} for non-signers len {len}")]
     InvalidInsertedNonSignerCount { inserted: u8, len: usize },
 
-    #[error("non-signer (index {index}) cannot be used as signer (max_index is {max_signer_index})")]
+    #[error("non-signer (index {index}) cannot be used as signer (valid signer index ranges are {old_signer_range:?} and {new_signer_range:?}, start inclusive and end exclusive)")]
     NonSignerCannotBeSigner {
         index: usize,
-        max_signer_index: usize,
+        old_signer_range: (usize, usize),
+        new_signer_range: (usize, usize),
     },
 }
 
@@ -202,10 +203,14 @@ impl Decrypt for PostDelegationActions {
         };
         let inserted_total = inserted_signers + inserted_non_signers;
         let new_signers_count = signers_count - inserted_signers;
+
+        let old_signer_range = (0, inserted_signers);
+        let new_signer_range =
+            (inserted_total, inserted_total + new_signers_count);
+
         let is_signer_idx = |idx: usize| {
-            idx < inserted_signers
-                || (idx >= inserted_total
-                    && idx < (inserted_total + new_signers_count))
+            (old_signer_range.0..old_signer_range.1).contains(&idx)
+                || (new_signer_range.0..new_signer_range.1).contains(&idx)
         };
 
         let instructions = actions
@@ -236,8 +241,8 @@ impl Decrypt for PostDelegationActions {
                                 return Err(
                                     DecryptError::NonSignerCannotBeSigner {
                                         index: idx,
-                                        max_signer_index: signers_count
-                                            .saturating_sub(1),
+                                        old_signer_range,
+                                        new_signer_range,
                                     },
                                 );
                             }

--- a/src/processor/fast/delegate_with_actions.rs
+++ b/src/processor/fast/delegate_with_actions.rs
@@ -108,6 +108,9 @@ pub fn process_delegate_with_actions(
         let signers_count = args.actions.signers.len() as u8;
         let keys_count = signers_count + args.actions.non_signers.len() as u8;
 
+        // Validate clear-text indices early when possible. Encrypted
+        // AccountMetas are skipped here because they can only be validated
+        // after decryption by the ER validator.
         for ix in args.actions.instructions.iter() {
             require!(
                 ix.program_id < keys_count,
@@ -121,7 +124,7 @@ pub fn process_delegate_with_actions(
                 };
                 require!(
                     (meta.is_signer() && meta.key() < signers_count)
-                        || meta.key() < keys_count,
+                        || (!meta.is_signer() && meta.key() < keys_count),
                     ProgramError::InvalidInstructionData
                 );
             }

--- a/tests/test_cleartext_with_insertable_encrypted.rs
+++ b/tests/test_cleartext_with_insertable_encrypted.rs
@@ -3,21 +3,20 @@ use dlp_api::{
     instruction_builder::{
         Encrypt, Encryptable, EncryptableFrom, PostDelegationInstruction,
     },
+    Decrypt,
 };
 use solana_instruction::{AccountMeta as IxAccountMeta, Instruction};
 use solana_program::{
-    instruction::AccountMeta as ProgramAccountMeta,
+    instruction::{
+        AccountMeta as ProgramAccountMeta, Instruction as ProgramInstruction,
+    },
     pubkey::Pubkey as ProgramPubkey,
 };
 use solana_pubkey::Pubkey as IxPubkey;
 use solana_sdk::signature::{Keypair, Signer};
 
-fn pk_program(byte: u8) -> ProgramPubkey {
-    ProgramPubkey::new_from_array([byte; 32])
-}
-
-fn pk_ix(byte: u8) -> IxPubkey {
-    IxPubkey::new_from_array([byte; 32])
+fn pk(byte: u8) -> [u8; 32] {
+    [byte; 32]
 }
 
 #[test]
@@ -28,12 +27,12 @@ fn test_cleartext_with_insertable_encrypted_actions() {
 
     // Off-chain: user builds a regular instruction and then chooses which parts
     // should be encrypted by converting to PostDelegationInstruction.
-    let insert_program = pk_program(10);
-    let s1 = pk_program(1);
-    let s2 = pk_program(2);
-    let n1 = pk_program(3);
-    let n2 = pk_program(4);
-    let n3 = pk_program(5);
+    let insert_program = ProgramPubkey::new_from_array(pk(10));
+    let s1 = ProgramPubkey::new_from_array(pk(1));
+    let s2 = ProgramPubkey::new_from_array(pk(2));
+    let n1 = ProgramPubkey::new_from_array(pk(3));
+    let n2 = ProgramPubkey::new_from_array(pk(4));
+    let n3 = ProgramPubkey::new_from_array(pk(5));
 
     let insert_ix = PostDelegationInstruction {
         // Encrypt program id to keep cleartext keys total at 4 (2 signers + 2 non-signers).
@@ -55,18 +54,30 @@ fn test_cleartext_with_insertable_encrypted_actions() {
     // On-chain: insert the encrypted actions between two cleartext instructions.
     let actions = vec![
         Instruction {
-            program_id: pk_ix(20),
+            program_id: IxPubkey::new_from_array(pk(20)),
             accounts: vec![
-                IxAccountMeta::new_readonly(pk_ix(21), true),
-                IxAccountMeta::new_readonly(pk_ix(22), false),
+                IxAccountMeta::new_readonly(
+                    IxPubkey::new_from_array(pk(21)),
+                    true,
+                ),
+                IxAccountMeta::new_readonly(
+                    IxPubkey::new_from_array(pk(22)),
+                    false,
+                ),
             ],
             data: vec![1, 2, 3],
         },
         Instruction {
-            program_id: pk_ix(30),
+            program_id: IxPubkey::new_from_array(pk(30)),
             accounts: vec![
-                IxAccountMeta::new_readonly(pk_ix(31), true),
-                IxAccountMeta::new_readonly(pk_ix(32), false),
+                IxAccountMeta::new_readonly(
+                    IxPubkey::new_from_array(pk(31)),
+                    true,
+                ),
+                IxAccountMeta::new_readonly(
+                    IxPubkey::new_from_array(pk(32)),
+                    false,
+                ),
             ],
             data: vec![4, 5, 6],
         },
@@ -84,4 +95,49 @@ fn test_cleartext_with_insertable_encrypted_actions() {
     assert!(!is_encrypted(&actions.instructions[0]));
     assert!(is_encrypted(&actions.instructions[1]));
     assert!(!is_encrypted(&actions.instructions[2]));
+
+    let decrypted = actions.decrypt_with_keypair(&validator).unwrap();
+    let expected = vec![
+        ProgramInstruction {
+            program_id: ProgramPubkey::new_from_array(pk(20)),
+            accounts: vec![
+                ProgramAccountMeta::new_readonly(
+                    ProgramPubkey::new_from_array(pk(21)),
+                    true,
+                ),
+                ProgramAccountMeta::new_readonly(
+                    ProgramPubkey::new_from_array(pk(22)),
+                    false,
+                ),
+            ],
+            data: vec![1, 2, 3],
+        },
+        ProgramInstruction {
+            program_id: insert_program,
+            accounts: vec![
+                ProgramAccountMeta::new_readonly(s1, true),
+                ProgramAccountMeta::new_readonly(s2, true),
+                ProgramAccountMeta::new_readonly(n1, false),
+                ProgramAccountMeta::new_readonly(n2, false),
+                ProgramAccountMeta::new_readonly(n3, false),
+            ],
+            data: vec![9, 9, 9],
+        },
+        ProgramInstruction {
+            program_id: ProgramPubkey::new_from_array(pk(30)),
+            accounts: vec![
+                ProgramAccountMeta::new_readonly(
+                    ProgramPubkey::new_from_array(pk(31)),
+                    true,
+                ),
+                ProgramAccountMeta::new_readonly(
+                    ProgramPubkey::new_from_array(pk(32)),
+                    false,
+                ),
+            ],
+            data: vec![4, 5, 6],
+        },
+    ];
+
+    assert_eq!(decrypted, expected);
 }

--- a/tests/test_cleartext_with_insertable_encrypted.rs
+++ b/tests/test_cleartext_with_insertable_encrypted.rs
@@ -1,9 +1,13 @@
 use dlp_api::{
-    compact::ClearTextWithInsertable,
+    args::{
+        EncryptedBuffer, MaybeEncryptedAccountMeta, MaybeEncryptedInstruction,
+        MaybeEncryptedIxData, MaybeEncryptedPubkey, PostDelegationActions,
+    },
+    compact::{AccountMeta as CompactAccountMeta, ClearTextWithInsertable},
     instruction_builder::{
         Encrypt, Encryptable, EncryptableFrom, PostDelegationInstruction,
     },
-    Decrypt,
+    Decrypt, DecryptError,
 };
 use solana_instruction::{AccountMeta as IxAccountMeta, Instruction};
 use solana_program::{
@@ -140,4 +144,88 @@ fn test_cleartext_with_insertable_encrypted_actions() {
     ];
 
     assert_eq!(decrypted, expected);
+}
+
+#[test]
+fn test_decrypt_rejects_invalid_inserted_signer_count() {
+    let validator = Keypair::new();
+    let actions = PostDelegationActions {
+        inserted_signers: 2,
+        inserted_non_signers: 0,
+        signers: vec![pk(1)],
+        non_signers: vec![],
+        instructions: vec![],
+    };
+
+    let err = actions.decrypt_with_keypair(&validator).unwrap_err();
+    match err {
+        DecryptError::InvalidInsertedSignerCount { inserted, len } => {
+            assert_eq!(inserted, 2);
+            assert_eq!(len, 1);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn test_decrypt_rejects_invalid_inserted_non_signer_count() {
+    let validator = Keypair::new();
+    let actions = PostDelegationActions {
+        inserted_signers: 0,
+        inserted_non_signers: 1,
+        signers: vec![],
+        non_signers: vec![],
+        instructions: vec![],
+    };
+
+    let err = actions.decrypt_with_keypair(&validator).unwrap_err();
+    match err {
+        DecryptError::InvalidInsertedNonSignerCount { inserted, len } => {
+            assert_eq!(inserted, 1);
+            assert_eq!(len, 0);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn test_decrypt_rejects_non_signer_marked_as_signer() {
+    let validator = Keypair::new();
+    let actions = PostDelegationActions {
+        inserted_signers: 1,
+        inserted_non_signers: 1,
+        // Final stored layout is [old_signers, new_signers].
+        signers: vec![pk(1), pk(2)],
+        // Final stored layout is [old_non_signers, new_non_signers].
+        non_signers: vec![
+            MaybeEncryptedPubkey::ClearText(pk(3)),
+            MaybeEncryptedPubkey::ClearText(pk(4)),
+        ],
+        instructions: vec![MaybeEncryptedInstruction {
+            program_id: 3,
+            accounts: vec![MaybeEncryptedAccountMeta::ClearText(
+                // Index 1 is an old non-signer in the imagined compact order:
+                // [old_signers, old_non_signers, new_signers, new_non_signers].
+                CompactAccountMeta::new_readonly(1, true),
+            )],
+            data: MaybeEncryptedIxData {
+                prefix: vec![],
+                suffix: EncryptedBuffer::default(),
+            },
+        }],
+    };
+
+    let err = actions.decrypt_with_keypair(&validator).unwrap_err();
+    match err {
+        DecryptError::NonSignerCannotBeSigner {
+            index,
+            old_signer_range,
+            new_signer_range,
+        } => {
+            assert_eq!(index, 1);
+            assert_eq!(old_signer_range, (0, 1));
+            assert_eq!(new_signer_range, (2, 3));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 }


### PR DESCRIPTION
- Enforce signers requirement while decrypting `PostDelegationActions` into `Vec<Instruction>`.
  - Added a test.
- Validate clear-text indices and exit early on inconsistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed guidance on delegation action construction modes and account metadata handling.

* **Bug Fixes**
  * Enhanced validation of signer and account metadata consistency checks.
  * Improved error handling with more specific validation error variants.
  * Strengthened overflow detection for account counters.

* **Tests**
  * Added decryption verification tests.
  * Added negative test cases for invalid signer/account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->