### PR TITLE
release dlp-api v0.4.0 (DO NOT MERGE IT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "assertables",
  "bincode",
@@ -3063,13 +3063,13 @@ dependencies = [
  "solana-system-interface 2.0.0",
  "static_assertions",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "borsh 1.5.7",
@@ -3096,7 +3096,7 @@ dependencies = [
  "spl-token",
  "static_assertions",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "magicblock-delegation-program"
 description = "Delegation program for the Ephemeral Rollups"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"
@@ -46,7 +46,7 @@ log-cost = []
 logging = []
 
 [dependencies]
-magicblock-delegation-program-api = { version = "0.3.0", path = "dlp-api", default-features = false }
+magicblock-delegation-program-api = { version = "0.4.0", path = "dlp-api", default-features = false }
 bincode = { version = "^1.3" }
 borsh = { version = "1.5.3", features = [ "derive" ] }
 bytemuck = { version = ">=1", features = [ "derive" ] }
@@ -83,7 +83,7 @@ rand = { version = "0.8.5", features = ["small_rng"], optional = true }
 [dev-dependencies]
 assertables = "9.8.2"
 magicblock-delegation-program = { path = ".", features = ["unit_test_config"] }
-magicblock-delegation-program-api = { version = "0.3.0", path = "dlp-api" }
+magicblock-delegation-program-api = { version = "0.4.0", path = "dlp-api" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 solana-pubkey = "3.0.0"
 solana-program-test = "3.0.0"

--- a/dlp-api/Cargo.toml
+++ b/dlp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "magicblock-delegation-program-api"
 description = "Public API for the Magicblock delegation program"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
- release dlp-api with upgraded solana depedencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 1.3.0.
  * Updated magicblock-delegation-program-api dependency to version 0.4.0 across production and development dependencies.
  * Updated dlp-api crate version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->