### PR TITLE
release dlp-api v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "borsh 0.10.4",
@@ -2580,7 +2580,7 @@ dependencies = [
  "spl-token",
  "static_assertions",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ log-cost = []
 logging = []
 
 [dependencies]
-magicblock-delegation-program-api = { version = "0.3.0", path = "dlp-api", default-features = false }
+magicblock-delegation-program-api = { version = "1.0.0", path = "dlp-api", default-features = false }
 bincode = { version = "^1.3" }
 borsh = { version = "0.10.4" } 
 bytemuck = { version = ">=1", features = [ "derive" ] }
@@ -80,7 +80,7 @@ rand = { version = "=0.8.5", features = ["small_rng"], optional = true }
 [dev-dependencies]
 assertables = "9.8.2"
 magicblock-delegation-program = { path = ".", features = ["unit_test_config"] }
-magicblock-delegation-program-api = { version = "0.3.0", path = "dlp-api" }
+magicblock-delegation-program-api = { version = "1.0.0", path = "dlp-api" }
 rand = { version = "=0.8.5", features = ["small_rng"] }
 solana-pubkey = "3.0.0"
 solana-program-test = ">=1.16"

--- a/dlp-api/Cargo.toml
+++ b/dlp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "magicblock-delegation-program-api"
 description = "Public API for the Magicblock delegation program"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
- release `dlp-api` with downgraded borsh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `magicblock-delegation-program-api` to version 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->