### PR TITLE
fix: do index validation taking inserted-actions into account

### DIFF
--- a/dlp-api/src/args/delegate_with_actions.rs
+++ b/dlp-api/src/args/delegate_with_actions.rs
@@ -1,7 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use pinocchio::error::ProgramError;
 
 use super::DelegateArgs;
-use crate::compact;
+use crate::{compact, require};
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct DelegateWithActionsArgs {
@@ -10,6 +11,20 @@ pub struct DelegateWithActionsArgs {
 
     /// Compact post-delegation actions.
     pub actions: PostDelegationActions,
+}
+
+impl DelegateWithActionsArgs {
+    pub fn parse(data: &[u8]) -> Result<DelegateWithActionsArgs, ProgramError> {
+        let args = DelegateWithActionsArgs::try_from_slice(data)
+            .map_err(|_| ProgramError::InvalidInstructionData)?;
+
+        require!(
+            args.actions.total_keys() <= compact::MAX_PUBKEYS,
+            ProgramError::InvalidInstructionData
+        );
+
+        Ok(args)
+    }
 }
 
 ///
@@ -28,8 +43,9 @@ pub struct DelegateWithActionsArgs {
 /// In the advanced form, an existing PostDelegationActions value (usually provided by an off-chain
 /// client) is combined with Vec<Instruction> (usually constructed on-chain) to produce a merged
 /// PostDelegationActions via ClearTextWithInsertable::cleartext_with_insertable, which allows the
-/// existing actions to be inserted at a specific instruction index. In this case, both inserted_signers
-/// and inserted_non_signers may be non-zero, and the imagined pubkey list takes this form:
+/// existing actions to be inserted in the provided Vec<_> at a specific index. In this case, both
+/// inserted_signers and inserted_non_signers may be non-zero, and the imagined pubkey list takes
+/// this form (old_signers and old_non_signers are from insertable PostDelegationActions):
 ///
 ///   [old_signers.., old_non_signers.., new_signers.., new_non_signers..]
 ///
@@ -42,6 +58,28 @@ pub struct DelegateWithActionsArgs {
 ///
 ///  [old_non_signers.., new_non_signers..]
 ///
+/// Example,
+///
+/// ```ignore
+///
+/// let instructions: Vec<Instruction> = on_chain_instructions();
+///
+/// let merged_actions = instructions.cleartext_with_insertable(insertable_actions, 1);
+///
+/// ```
+///
+/// Assume insertable_actions has 2 signers and 3 non-signers pubkeys, then we have the
+/// following index ordering and merged_actions.
+///
+/// | ----------------------- index ordering ----------------------------------
+/// | inserted-signers | inserted-non-signers | new-signers | new-non-signers |
+/// |  0 1             |  2 3 4               | 5           | 6 7             |
+/// | ------------------------ merged actions ---------------------------------
+/// | merged_actions.inserted_signers     = 2                                 |
+/// | merged_actions.inserted_non_signers = 3                                 |
+/// | merged_actions.signers              = [pk_0, pk_1, pk_5]                |
+/// | merged_actions.non_signers          = [pk_2, pk_3, pk_4, pk_6, pk_7]    |
+/// ---------------------------------------------------------------------------
 ///
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PostDelegationActions {
@@ -54,6 +92,40 @@ pub struct PostDelegationActions {
     pub non_signers: Vec<MaybeEncryptedPubkey>,
 
     pub instructions: Vec<MaybeEncryptedInstruction>,
+}
+
+///
+/// AddressIndex is a validated index, returned by validate_index()
+///
+#[derive(Copy, Clone)]
+pub struct AddressIndex(u8);
+
+impl PostDelegationActions {
+    pub fn total_inserted(&self) -> u8 {
+        self.inserted_signers + self.inserted_non_signers
+    }
+
+    pub fn total_keys(&self) -> u8 {
+        self.signers.len() as u8 + self.non_signers.len() as u8
+    }
+
+    pub fn validate_index(
+        &self,
+        index: u8,
+    ) -> Result<AddressIndex, ProgramError> {
+        require!(
+            index < self.total_keys(),
+            ProgramError::InvalidInstructionData
+        );
+        Ok(AddressIndex(index))
+    }
+
+    pub fn is_signer(&self, index: AddressIndex) -> bool {
+        let index = index.0;
+        index < self.inserted_signers
+            || (index >= self.total_inserted()
+                && index < self.inserted_non_signers + self.signers.len() as u8)
+    }
 }
 
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]

--- a/dlp-api/src/args/delegate_with_actions.rs
+++ b/dlp-api/src/args/delegate_with_actions.rs
@@ -2,7 +2,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::error::ProgramError;
 
 use super::DelegateArgs;
-use crate::{compact, require, require_le};
+use crate::{
+    compact::{self, MAX_PUBKEYS},
+    require, require_le,
+};
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct DelegateWithActionsArgs {
@@ -18,23 +21,7 @@ impl DelegateWithActionsArgs {
         let args = DelegateWithActionsArgs::try_from_slice(data)
             .map_err(|_| ProgramError::InvalidInstructionData)?;
 
-        require_le!(
-            args.actions.inserted_signers as usize,
-            args.actions.signers.len(),
-            ProgramError::InvalidInstructionData
-        );
-
-        require_le!(
-            args.actions.inserted_non_signers as usize,
-            args.actions.non_signers.len(),
-            ProgramError::InvalidInstructionData
-        );
-
-        require_le!(
-            args.actions.total_keys(),
-            compact::MAX_PUBKEYS,
-            ProgramError::InvalidInstructionData
-        );
+        PostDelegationActions::validate(&args.actions)?;
 
         Ok(args)
     }
@@ -110,16 +97,41 @@ pub struct PostDelegationActions {
 ///
 /// AddressIndex is a validated index, returned by validate_index()
 ///
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AddressIndex(u8);
 
 impl PostDelegationActions {
-    pub fn total_inserted(&self) -> u8 {
-        self.inserted_signers + self.inserted_non_signers
+    pub fn validate(this: &PostDelegationActions) -> Result<(), ProgramError> {
+        require_le!(
+            this.inserted_signers as usize,
+            this.signers.len(),
+            ProgramError::InvalidInstructionData
+        );
+
+        require_le!(
+            this.inserted_non_signers as usize,
+            this.non_signers.len(),
+            ProgramError::InvalidInstructionData
+        );
+
+        this.total_inserted()?;
+        this.total_keys()?;
+
+        Ok(())
     }
 
-    pub fn total_keys(&self) -> u8 {
-        self.signers.len() as u8 + self.non_signers.len() as u8
+    pub fn total_inserted(&self) -> Result<u8, ProgramError> {
+        self.inserted_signers
+            .checked_add(self.inserted_non_signers)
+            .and_then(|total| (total <= MAX_PUBKEYS).then_some(total))
+            .ok_or(ProgramError::InvalidInstructionData)
+    }
+
+    pub fn total_keys(&self) -> Result<u8, ProgramError> {
+        (self.signers.len() as u8)
+            .checked_add(self.non_signers.len() as u8)
+            .and_then(|total| (total <= MAX_PUBKEYS).then_some(total))
+            .ok_or(ProgramError::InvalidInstructionData)
     }
 
     pub fn validate_index(
@@ -127,17 +139,21 @@ impl PostDelegationActions {
         index: u8,
     ) -> Result<AddressIndex, ProgramError> {
         require!(
-            index < self.total_keys(),
+            index < self.total_keys()?,
             ProgramError::InvalidInstructionData
         );
         Ok(AddressIndex(index))
     }
 
-    pub fn is_signer(&self, index: AddressIndex) -> bool {
+    pub fn is_signer(&self, index: AddressIndex) -> Result<bool, ProgramError> {
         let index = index.0;
-        index < self.inserted_signers
-            || (index >= self.total_inserted()
-                && index < self.inserted_non_signers + self.signers.len() as u8)
+        Ok(index < self.inserted_signers
+            || (index >= self.total_inserted()?
+                && index
+                    < self
+                        .inserted_non_signers
+                        .checked_add(self.signers.len() as u8)
+                        .ok_or(ProgramError::InvalidInstructionData)?))
     }
 }
 

--- a/dlp-api/src/args/delegate_with_actions.rs
+++ b/dlp-api/src/args/delegate_with_actions.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use pinocchio::error::ProgramError;
 
 use super::DelegateArgs;
-use crate::{compact, require};
+use crate::{compact, require, require_le};
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct DelegateWithActionsArgs {
@@ -18,8 +18,21 @@ impl DelegateWithActionsArgs {
         let args = DelegateWithActionsArgs::try_from_slice(data)
             .map_err(|_| ProgramError::InvalidInstructionData)?;
 
-        require!(
-            args.actions.total_keys() <= compact::MAX_PUBKEYS,
+        require_le!(
+            args.actions.inserted_signers as usize,
+            args.actions.signers.len(),
+            ProgramError::InvalidInstructionData
+        );
+
+        require_le!(
+            args.actions.inserted_non_signers as usize,
+            args.actions.non_signers.len(),
+            ProgramError::InvalidInstructionData
+        );
+
+        require_le!(
+            args.actions.total_keys(),
+            compact::MAX_PUBKEYS,
             ProgramError::InvalidInstructionData
         );
 

--- a/dlp-api/src/compact/mod.rs
+++ b/dlp-api/src/compact/mod.rs
@@ -266,6 +266,7 @@ impl ClearTextWithInsertable for Vec<solana_instruction::Instruction> {
         let old_total = old_signers_len + old_non_signers_len;
 
         let index_of = |pk: &solana_address::Address| -> u8 {
+            //
             // The final list will be this as per PostDelegationActions:
             //
             //  [insertable.signers..., new.signers..., insertable.non_signers..., new.non_signers...]

--- a/dlp-api/src/compact/mod.rs
+++ b/dlp-api/src/compact/mod.rs
@@ -402,6 +402,9 @@ mod tests {
             }],
         };
 
+        assert_eq!(insertable.signers.len(), 2);
+        assert_eq!(insertable.non_signers.len(), 3);
+
         let ns1 = pk(6);
         let nn1 = pk(7);
         let program_id = pk(8);
@@ -452,5 +455,20 @@ mod tests {
         assert_cleartext_meta(&new_ix.accounts[1], 5, true);
         assert_cleartext_meta(&new_ix.accounts[2], 7, false);
         assert_cleartext_meta(&new_ix.accounts[3], 8, false);
+
+        // a similar code is used in process_delegate_with_actions() to early validate actions
+        for ix in actions.instructions.iter() {
+            actions.validate_index(ix.program_id).unwrap();
+
+            for account in &ix.accounts {
+                let crate::args::MaybeEncryptedAccountMeta::ClearText(meta) =
+                    account
+                else {
+                    continue;
+                };
+                let index = actions.validate_index(meta.key()).unwrap();
+                assert_eq!(meta.is_signer(), actions.is_signer(index));
+            }
+        }
     }
 }

--- a/dlp-api/src/compact/mod.rs
+++ b/dlp-api/src/compact/mod.rs
@@ -467,7 +467,7 @@ mod tests {
                     continue;
                 };
                 let index = actions.validate_index(meta.key()).unwrap();
-                assert_eq!(meta.is_signer(), actions.is_signer(index));
+                assert_eq!(meta.is_signer(), actions.is_signer(index).unwrap());
             }
         }
     }

--- a/dlp-api/src/compact/mod.rs
+++ b/dlp-api/src/compact/mod.rs
@@ -173,82 +173,74 @@ impl ClearTextWithInsertable for Vec<solana_instruction::Instruction> {
         );
 
         // add keys from actions (pre-encrypted instructions)
-        let mut skipable_pubkeys: Vec<Option<Address>> = vec![];
-        {
+        let skipable_pubkeys: Vec<Option<Address>> = {
+            let mut skipable: Vec<Option<Address>> = vec![];
             for signer in insertable.signers.iter() {
-                skipable_pubkeys.push(Some((*signer).into()));
+                skipable.push(Some((*signer).into()));
             }
             for non_signer in insertable.non_signers.iter() {
                 if let MaybeEncryptedPubkey::ClearText(non_signer) = non_signer
                 {
-                    skipable_pubkeys.push(Some((*non_signer).into()));
+                    skipable.push(Some((*non_signer).into()));
                 } else {
-                    // Note that None is added to the list, to mark that this slot is encrypted but
-                    // the index is already taken so that the index in referred by insertable.instructions
-                    // is maintained/calculatable.
-                    skipable_pubkeys.push(None);
+                    // Important: None is added to the list, to mark that the pubkey (corresponding
+                    // to this index) is encrypted and the index is already taken, that prevents
+                    // other keys from taking this index. It ensures that the index referred
+                    // by insertable.instructions correctly points to this slot.
+                    skipable.push(None);
                 }
             }
-        }
+            skipable
+        };
 
         let mut signers: Vec<solana_instruction::AccountMeta> = Vec::new();
         let mut non_signers: Vec<solana_instruction::AccountMeta> = Vec::new();
 
-        let mut add_to_signers = |meta: &solana_instruction::AccountMeta| {
-            if skipable_pubkeys.contains(&Some(meta.pubkey)) {
-                return;
-            }
-
-            assert!(meta.is_signer, "AccountMeta must be a signer");
-            let Some(found) =
-                signers.iter_mut().find(|m| m.pubkey == meta.pubkey)
-            else {
-                signers.push(meta.clone());
-                return;
-            };
-
-            found.is_writable |= meta.is_writable;
-        };
-
-        let mut add_to_non_signers =
-            |meta: &solana_instruction::AccountMeta| {
+        let add_to =
+            |metas: &mut Vec<solana_instruction::AccountMeta>,
+             meta: &solana_instruction::AccountMeta| {
                 if skipable_pubkeys.contains(&Some(meta.pubkey)) {
                     return;
                 }
 
-                assert!(!meta.is_signer, "AccountMeta must not be a signer");
-                let Some(found) =
-                    non_signers.iter_mut().find(|m| m.pubkey == meta.pubkey)
-                else {
-                    non_signers.push(meta.clone());
-                    return;
-                };
-
-                found.is_writable |= meta.is_writable;
+                if let Some(found) =
+                    metas.iter_mut().find(|m| m.pubkey == meta.pubkey)
+                {
+                    found.is_writable |= meta.is_writable;
+                } else {
+                    metas.push(meta.clone());
+                }
             };
 
-        for meta in self
+        for signer_meta in self
             .iter()
             .flat_map(|ix| ix.accounts.iter())
             .filter(|meta| meta.is_signer)
         {
-            add_to_signers(meta);
+            add_to(&mut signers, signer_meta);
         }
 
         for ix in self.iter() {
-            add_to_non_signers(&solana_instruction::AccountMeta::new_readonly(
-                ix.program_id,
-                false,
-            ));
-            for meta in ix.accounts.iter().filter(|meta| !meta.is_signer) {
-                let Some(found) =
-                    signers.iter_mut().find(|m| m.pubkey == meta.pubkey)
-                else {
-                    add_to_non_signers(meta);
-                    continue;
-                };
-
-                found.is_writable |= meta.is_writable;
+            add_to(
+                &mut non_signers,
+                &solana_instruction::AccountMeta::new_readonly(
+                    ix.program_id,
+                    false,
+                ),
+            );
+            for non_signer_meta in
+                ix.accounts.iter().filter(|meta| !meta.is_signer)
+            {
+                if let Some(signer) = signers
+                    .iter_mut()
+                    .find(|m| m.pubkey == non_signer_meta.pubkey)
+                {
+                    // this non_signer_meta is previously seen as signer, so we need to
+                    // update its is_writable only.
+                    signer.is_writable |= non_signer_meta.is_writable;
+                } else {
+                    add_to(&mut non_signers, non_signer_meta);
+                }
             }
         }
 

--- a/dlp-api/src/decrypt.rs
+++ b/dlp-api/src/decrypt.rs
@@ -188,10 +188,10 @@ impl Decrypt for PostDelegationActions {
                 .non_signers
                 .iter()
                 .map(|non_signer| {
-                    Ok(non_signer.clone().decrypt(
+                    non_signer.clone().decrypt(
                         recipient_x25519_pubkey,
                         recipient_x25519_secret,
-                    )?)
+                    )
                 })
                 .collect::<Result<Vec<_>, DecryptError>>()?;
 

--- a/dlp-api/src/instruction_builder/delegate_with_actions.rs
+++ b/dlp-api/src/instruction_builder/delegate_with_actions.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "encryption")]
-
 use borsh::to_vec;
 use dlp::{
     args::{DelegateArgs, DelegateWithActionsArgs},

--- a/src/processor/fast/delegate_with_actions.rs
+++ b/src/processor/fast/delegate_with_actions.rs
@@ -1,3 +1,4 @@
+use dlp_api::require_eq;
 use pinocchio::{
     address::address_eq,
     cpi::{Seed, Signer},
@@ -17,7 +18,7 @@ use crate::{
         fast::{to_pinocchio_program_error, utils::pda::create_pda},
         utils::curve::is_on_curve_fast,
     },
-    require, require_n_accounts_with_optionals,
+    require_n_accounts_with_optionals,
     requires::{
         require_owned_pda, require_pda, require_signer,
         require_uninitialized_pda, DelegationMetadataCtx, DelegationRecordCtx,
@@ -108,8 +109,9 @@ pub fn process_delegate_with_actions(
                     continue;
                 };
                 let index = args.actions.validate_index(meta.key())?;
-                require!(
-                    meta.is_signer() == args.actions.is_signer(index),
+                require_eq!(
+                    meta.is_signer(),
+                    args.actions.is_signer(index),
                     ProgramError::InvalidInstructionData
                 );
             }
@@ -119,7 +121,11 @@ pub fn process_delegate_with_actions(
         for signer in &args.actions.signers {
             let account = remaining_accounts
                 .iter()
-                .find(|account| &account.address().to_bytes() == signer)
+                .find(|account| {
+                    address_eq(account.address(), unsafe {
+                        &*(signer.as_ptr() as *const Address)
+                    })
+                })
                 .ok_or(ProgramError::NotEnoughAccountKeys)?;
             if !account.is_signer() {
                 return Err(ProgramError::MissingRequiredSignature);

--- a/src/processor/fast/delegate_with_actions.rs
+++ b/src/processor/fast/delegate_with_actions.rs
@@ -1,4 +1,3 @@
-use borsh::BorshDeserialize;
 use pinocchio::{
     address::address_eq,
     cpi::{Seed, Signer},
@@ -11,7 +10,6 @@ use pinocchio_system::instructions as system;
 
 use crate::{
     args::DelegateWithActionsArgs,
-    compact,
     consts::{DEFAULT_VALIDATOR_IDENTITY, RENT_EXCEPTION_ZERO_BYTES_LAMPORTS},
     error::DlpError,
     pda,
@@ -92,39 +90,26 @@ pub fn process_delegate_with_actions(
         DelegationMetadataCtx,
     )?;
 
-    let args: DelegateWithActionsArgs =
-        DelegateWithActionsArgs::try_from_slice(data)
-            .map_err(|_| ProgramError::InvalidInstructionData)?;
+    let args: DelegateWithActionsArgs = DelegateWithActionsArgs::parse(data)?;
 
     // Validate instruction payload shape up-front. This confirms delegate args
     // and actions envelope format, while encrypted bytes remain opaque.
     {
-        if (args.actions.signers.len() + args.actions.non_signers.len())
-            > compact::MAX_PUBKEYS as usize
-        {
-            return Err(ProgramError::InvalidInstructionData);
-        }
-
-        let signers_count = args.actions.signers.len() as u8;
-        let keys_count = signers_count + args.actions.non_signers.len() as u8;
-
         // Validate clear-text indices early when possible. Encrypted
         // AccountMetas are skipped here because they can only be validated
         // after decryption by the ER validator.
         for ix in args.actions.instructions.iter() {
-            require!(
-                ix.program_id < keys_count,
-                ProgramError::InvalidInstructionData
-            );
+            args.actions.validate_index(ix.program_id)?;
+
             for account in &ix.accounts {
                 let crate::args::MaybeEncryptedAccountMeta::ClearText(meta) =
                     account
                 else {
                     continue;
                 };
+                let index = args.actions.validate_index(meta.key())?;
                 require!(
-                    (meta.is_signer() && meta.key() < signers_count)
-                        || (!meta.is_signer() && meta.key() < keys_count),
+                    meta.is_signer() == args.actions.is_signer(index),
                     ProgramError::InvalidInstructionData
                 );
             }

--- a/src/processor/fast/delegate_with_actions.rs
+++ b/src/processor/fast/delegate_with_actions.rs
@@ -111,7 +111,7 @@ pub fn process_delegate_with_actions(
                 let index = args.actions.validate_index(meta.key())?;
                 require_eq!(
                     meta.is_signer(),
-                    args.actions.is_signer(index),
+                    args.actions.is_signer(index)?,
                     ProgramError::InvalidInstructionData
                 );
             }


### PR DESCRIPTION
We have `insertable` actions, but the index validation was not taking that into account. It was working because till now _only_ "insertable" actions had signers but with _gasless_ transactions, both _insertable_ actions and _instructions_ (to which _insertable_ is inserted) have signers. So this PR computes the signer-index correctly (see `is_signer(index: u8)`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better validation to catch malformed delegation inputs and signer/index mismatches; improved mapping of invalid instruction data to errors.

* **Improvements**
  * Stricter bounds and index validation for inserted/total keys; more consistent signer vs non-signer classification and simplified key-merging behavior.

* **Tests**
  * Strengthened unit tests to assert action index validity and signer correctness.

* **Documentation**
  * Updated docs and example describing insertion ordering and merged output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->