### PR TITLE
fix: prevent u64 underflow in validator_claim_fees and use on-chain Rent sysvar

### DIFF
--- a/src/processor/validator_claim_fees.rs
+++ b/src/processor/validator_claim_fees.rs
@@ -2,6 +2,7 @@ use borsh::BorshDeserialize;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg,
     program_error::ProgramError, pubkey::Pubkey, rent::Rent,
+    sysvar::Sysvar,
 };
 
 use crate::{
@@ -49,18 +50,26 @@ pub fn process_validator_claim_fees(
         true,
     )?;
 
-    // Calculate the amount to transfer
-    let min_rent = Rent::default().minimum_balance(8);
-    let amount = args
-        .amount
-        .unwrap_or(validator_fees_vault.lamports() - min_rent);
+    // Use the on-chain Rent sysvar (not `Rent::default()`) and the actual
+    // account data length so the minimum-balance threshold is always accurate.
+    let min_rent =
+        Rent::get()?.minimum_balance(validator_fees_vault.data_len());
+
+    // Guard against underflow: if the vault somehow holds fewer lamports than
+    // the rent-exempt minimum, return an error instead of wrapping around.
+    let available = validator_fees_vault
+        .lamports()
+        .checked_sub(min_rent)
+        .ok_or(ProgramError::InsufficientFunds)?;
+
+    let amount = args.amount.unwrap_or(available);
 
     // Ensure vault has enough lamports
-    if validator_fees_vault.lamports() - min_rent < amount {
+    if available < amount {
         msg!(
             "Vault ({}) has insufficient funds: {} < {}",
             validator_fees_vault.key,
-            validator_fees_vault.lamports() - min_rent,
+            available,
             amount
         );
         return Err(ProgramError::InsufficientFunds);


### PR DESCRIPTION
## Summary

This PR fixes two related bugs in `process_validator_claim_fees` (`src/processor/validator_claim_fees.rs`).

---

### Bug 1 — `Rent::default()` uses hardcoded values, not the on-chain schedule

```rust
// Before
let min_rent = Rent::default().minimum_balance(8);
```

`Rent::default()` constructs a `Rent` struct with compile-time defaults that may drift from the actual on-chain rent configuration. The correct approach is to read the Sysvar from the runtime via `Rent::get()?`. Additionally the hardcoded data-length argument `8` is replaced with the actual `validator_fees_vault.data_len()` so the minimum-balance threshold is always correct regardless of account size.

---

### Bug 2 — Unchecked subtraction can underflow and bypass the insufficient-funds guard

```rust
// Before (appears twice)
let amount = args.amount.unwrap_or(validator_fees_vault.lamports() - min_rent);
if validator_fees_vault.lamports() - min_rent < amount { ... }
```

Both subtractions are plain `u64` arithmetic. If the vault ever holds fewer lamports than `min_rent` (possible after a prior accounting error or if a griefing vector reduces the balance below rent-exemption), the subtraction wraps around in release builds to a very large `u64`. This makes `amount` a huge default value and causes the guard condition to evaluate incorrectly, potentially allowing an unauthorised withdrawal of an arbitrary amount.

**Fix:** Compute the available balance once with `checked_sub(...).ok_or(ProgramError::InsufficientFunds)?` and reuse the result, eliminating both raw subtractions.

---

### Fix

```rust
// After
let min_rent = Rent::get()?.minimum_balance(validator_fees_vault.data_len());
let available = validator_fees_vault
    .lamports()
    .checked_sub(min_rent)
    .ok_or(ProgramError::InsufficientFunds)?;
let amount = args.amount.unwrap_or(available);
if available < amount { ... }
```

### Impact
- Severity: **Critical** — arithmetic underflow in an on-chain fee-claim instruction can lead to fund loss
- Affected component: `delegation-program / src/processor/validator_claim_fees.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of rent-exempt balance calculations in validator fee claiming by using actual account data instead of hardcoded values.
  * Enhanced safety checks to prevent arithmetic underflow and provide clearer error messages for insufficient funds scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->