### PR TITLE
security: use stronger check in Undelegate

### DIFF
--- a/src/processor/fast/undelegate.rs
+++ b/src/processor/fast/undelegate.rs
@@ -1,4 +1,4 @@
-use dlp_api::compat::borsh;
+use dlp_api::{compat::borsh, require_eq_keys};
 use pinocchio::{
     address::{address_eq, Address},
     cpi::{invoke_signed, Signer},
@@ -161,6 +161,12 @@ pub fn process_undelegate(
             &delegation_record_data,
         )
         .map_err(to_pinocchio_program_error)?;
+
+    require_eq_keys!(
+        &delegation_record.authority,
+        validator.address(),
+        DlpError::InvalidAuthority
+    );
 
     // Check passed owner and owner stored in the delegation record match
     if !address_eq(

--- a/tests/test_undelegate_on_curve.rs
+++ b/tests/test_undelegate_on_curve.rs
@@ -91,7 +91,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
 
     // Setup the delegated record PDA
     let delegation_record_data = get_delegation_record_on_curve_data(
-        payer_alt.pubkey(),
+        validator.pubkey(),
         Some(LAMPORTS_PER_SOL),
     );
     program_test.add_account(


### PR DESCRIPTION
Just making undelegate super-safe.