### PR TITLE
feat(fraud-proofs): Implement RegisterOperator

### DIFF
--- a/dlp-api/src/v2/args/mod.rs
+++ b/dlp-api/src/v2/args/mod.rs
@@ -2,5 +2,7 @@
 // instruction tag, so v2 instruction args use `buffer_offset = 1`.
 
 mod init_protocol_config;
+mod register_operator;
 
 pub use init_protocol_config::*;
+pub use register_operator::*;

--- a/dlp-api/src/v2/args/register_operator.rs
+++ b/dlp-api/src/v2/args/register_operator.rs
@@ -1,0 +1,20 @@
+use wheels::{layout::Decodable, variable_offset_layout};
+
+use crate::solana_program::program_error::ProgramError;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[variable_offset_layout(buffer_offset = unaligned)]
+pub struct RegisterOperatorArgs {
+    pub amount_lamports: u64,
+}
+
+impl RegisterOperatorArgs {
+    pub fn try_from_bytes(data: &[u8]) -> Result<Self, ProgramError> {
+        let view = <Self as Decodable>::decode(data)
+            .map_err(super::super::state::layout_error_to_program_error)?;
+
+        Ok(Self {
+            amount_lamports: view.amount_lamports(),
+        })
+    }
+}

--- a/dlp-api/src/v2/args/register_operator.rs
+++ b/dlp-api/src/v2/args/register_operator.rs
@@ -1,20 +1,7 @@
-use wheels::{layout::Decodable, variable_offset_layout};
-
-use crate::solana_program::program_error::ProgramError;
+use wheels::variable_offset_layout;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[variable_offset_layout(buffer_offset = unaligned)]
+#[variable_offset_layout(buffer_offset = 0)]
 pub struct RegisterOperatorArgs {
     pub amount_lamports: u64,
-}
-
-impl RegisterOperatorArgs {
-    pub fn try_from_bytes(data: &[u8]) -> Result<Self, ProgramError> {
-        let view = <Self as Decodable>::decode(data)
-            .map_err(super::super::state::layout_error_to_program_error)?;
-
-        Ok(Self {
-            amount_lamports: view.amount_lamports(),
-        })
-    }
 }

--- a/dlp-api/src/v2/args/register_operator.rs
+++ b/dlp-api/src/v2/args/register_operator.rs
@@ -1,7 +1,7 @@
 use wheels::variable_offset_layout;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[variable_offset_layout(buffer_offset = 0)]
+#[variable_offset_layout(buffer_offset = 1)]
 pub struct RegisterOperatorArgs {
     pub amount_lamports: u64,
 }

--- a/dlp-api/src/v2/args/register_operator.rs
+++ b/dlp-api/src/v2/args/register_operator.rs
@@ -3,5 +3,5 @@ use wheels::variable_offset_layout;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[variable_offset_layout(buffer_offset = 1)]
 pub struct RegisterOperatorArgs {
-    pub amount_lamports: u64,
+    pub stake_lamports: u64,
 }

--- a/dlp-api/src/v2/instruction.rs
+++ b/dlp-api/src/v2/instruction.rs
@@ -7,6 +7,8 @@ use strum::IntoStaticStr;
 pub enum DlpV2Instruction {
     /// Creates the global v2 protocol config and verifier registry accounts.
     InitProtocolConfig = 100,
+    /// Registers one operator and deposits its initial stake.
+    RegisterOperator = 101,
 }
 
 impl DlpV2Instruction {

--- a/dlp-api/src/v2/instruction_builder/mod.rs
+++ b/dlp-api/src/v2/instruction_builder/mod.rs
@@ -1,3 +1,5 @@
 mod init_protocol_config;
+mod register_operator;
 
 pub use init_protocol_config::*;
+pub use register_operator::*;

--- a/dlp-api/src/v2/instruction_builder/register_operator.rs
+++ b/dlp-api/src/v2/instruction_builder/register_operator.rs
@@ -1,0 +1,40 @@
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+use solana_sdk_ids::system_program;
+use wheels::layout::Encodable;
+
+use crate::{
+    compat::{Compatize, Modernize},
+    v2::{
+        pda::{operator_bond_pda, protocol_config_pda},
+        DlpV2Instruction, RegisterOperatorArgs,
+    },
+};
+
+/// Builds the instruction that registers one operator for v2 commitments.
+pub fn register_operator(
+    operator: Pubkey,
+    authority: Pubkey,
+    args: RegisterOperatorArgs,
+) -> Instruction {
+    Instruction {
+        program_id: crate::id().modernize(),
+        accounts: vec![
+            AccountMeta::new(operator, true),
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(
+                operator_bond_pda(&operator.compatize()).modernize(),
+                false,
+            ),
+            AccountMeta::new_readonly(protocol_config_pda().modernize(), false),
+            AccountMeta::new_readonly(system_program::id(), false),
+        ],
+        data: [
+            DlpV2Instruction::RegisterOperator.to_vec(),
+            args.encode().unwrap(),
+        ]
+        .concat(),
+    }
+}

--- a/dlp-api/src/v2/pda.rs
+++ b/dlp-api/src/v2/pda.rs
@@ -1,6 +1,7 @@
 use crate::compat::Pubkey;
 
 pub const PROTOCOL_CONFIG_SEED: &[u8] = b"protocol-config";
+pub const OPERATOR_BOND_SEED: &[u8] = b"operator-bond";
 pub const VERIFIER_REGISTRY_SEED: &[u8] = b"verifier-registry";
 
 // TODO (snawaz): Precompute these addresses if PDA derivation becomes const-safe.
@@ -11,4 +12,12 @@ pub fn protocol_config_pda() -> Pubkey {
 
 pub fn verifier_registry_pda() -> Pubkey {
     Pubkey::find_program_address(&[VERIFIER_REGISTRY_SEED], &crate::id()).0
+}
+
+pub fn operator_bond_pda(operator: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[OPERATOR_BOND_SEED, operator.as_ref()],
+        &crate::id(),
+    )
+    .0
 }

--- a/dlp-api/src/v2/state/mod.rs
+++ b/dlp-api/src/v2/state/mod.rs
@@ -1,5 +1,7 @@
+mod operator_bond;
 mod protocol_config;
 mod verifier_registry;
 
+pub use operator_bond::*;
 pub use protocol_config::*;
 pub use verifier_registry::*;

--- a/dlp-api/src/v2/state/operator_bond.rs
+++ b/dlp-api/src/v2/state/operator_bond.rs
@@ -1,9 +1,6 @@
-use wheels::{
-    fixed_offset_layout,
-    layout::{Decodable, Encodable},
-};
+use wheels::fixed_offset_layout;
 
-use crate::{compat::Pubkey, solana_program::program_error::ProgramError};
+use crate::compat::Pubkey;
 
 pub const OPERATOR_STATUS_ACTIVE: u8 = 1;
 pub const OPERATOR_STATUS_EXITING: u8 = 2;
@@ -13,46 +10,25 @@ pub const OPERATOR_STATUS_JAILED: u8 = 4;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[fixed_offset_layout(buffer_offset = 0)]
 pub struct OperatorBond {
+    /// Account type marker.
+    pub discriminator: [u8; 8],
+
+    /// Operator identity allowed to post commitments through this bond.
     pub operator_identity: Pubkey,
+
+    /// Slashable operator stake held in this account.
     pub stake_lamports: u64,
+
+    /// Stake reserved by active commitments.
     pub locked_lamports: u64,
+
+    /// Current operator lifecycle state.
     pub status: u8,
+
+    /// Slot when withdrawal was requested, if the operator is exiting.
     pub withdraw_requested_slot: Option<u64>,
 }
 
 impl OperatorBond {
     pub const DISCRIMINATOR: [u8; 8] = *b"v2opbond";
-    pub const SPACE: usize = 8 + Self::DATA_LEN;
-
-    pub fn to_bytes_with_discriminator(
-        &self,
-        data: &mut [u8],
-    ) -> Result<(), ProgramError> {
-        let payload = super::utils::payload_with_discriminator_mut(
-            &Self::DISCRIMINATOR,
-            data,
-        )?;
-        self.encode_to(payload)
-            .map_err(super::utils::layout_error_to_program_error)?;
-        Ok(())
-    }
-
-    pub fn try_from_bytes_with_discriminator(
-        data: &[u8],
-    ) -> Result<Self, ProgramError> {
-        let payload = super::utils::payload_with_discriminator(
-            &Self::DISCRIMINATOR,
-            data,
-        )?;
-        let view = <Self as Decodable>::decode(payload)
-            .map_err(super::utils::layout_error_to_program_error)?;
-
-        Ok(Self {
-            operator_identity: *view.operator_identity(),
-            stake_lamports: view.stake_lamports(),
-            locked_lamports: view.locked_lamports(),
-            status: view.status(),
-            withdraw_requested_slot: view.withdraw_requested_slot(),
-        })
-    }
 }

--- a/dlp-api/src/v2/state/operator_bond.rs
+++ b/dlp-api/src/v2/state/operator_bond.rs
@@ -1,0 +1,58 @@
+use wheels::{
+    fixed_offset_layout,
+    layout::{Decodable, Encodable},
+};
+
+use crate::{compat::Pubkey, solana_program::program_error::ProgramError};
+
+pub const OPERATOR_STATUS_ACTIVE: u8 = 1;
+pub const OPERATOR_STATUS_EXITING: u8 = 2;
+pub const OPERATOR_STATUS_SLASHED: u8 = 3;
+pub const OPERATOR_STATUS_JAILED: u8 = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[fixed_offset_layout(buffer_offset = 0)]
+pub struct OperatorBond {
+    pub operator_identity: Pubkey,
+    pub stake_lamports: u64,
+    pub locked_lamports: u64,
+    pub status: u8,
+    pub withdraw_requested_slot: Option<u64>,
+}
+
+impl OperatorBond {
+    pub const DISCRIMINATOR: [u8; 8] = *b"v2opbond";
+    pub const SPACE: usize = 8 + Self::DATA_LEN;
+
+    pub fn to_bytes_with_discriminator(
+        &self,
+        data: &mut [u8],
+    ) -> Result<(), ProgramError> {
+        let payload = super::utils::payload_with_discriminator_mut(
+            &Self::DISCRIMINATOR,
+            data,
+        )?;
+        self.encode_to(payload)
+            .map_err(super::utils::layout_error_to_program_error)?;
+        Ok(())
+    }
+
+    pub fn try_from_bytes_with_discriminator(
+        data: &[u8],
+    ) -> Result<Self, ProgramError> {
+        let payload = super::utils::payload_with_discriminator(
+            &Self::DISCRIMINATOR,
+            data,
+        )?;
+        let view = <Self as Decodable>::decode(payload)
+            .map_err(super::utils::layout_error_to_program_error)?;
+
+        Ok(Self {
+            operator_identity: *view.operator_identity(),
+            stake_lamports: view.stake_lamports(),
+            locked_lamports: view.locked_lamports(),
+            status: view.status(),
+            withdraw_requested_slot: view.withdraw_requested_slot(),
+        })
+    }
+}

--- a/dlp-api/src/v2/state/operator_bond.rs
+++ b/dlp-api/src/v2/state/operator_bond.rs
@@ -2,27 +2,29 @@ use wheels::fixed_offset_layout;
 
 use crate::compat::Pubkey;
 
-pub const OPERATOR_STATUS_ACTIVE: u8 = 1;
-pub const OPERATOR_STATUS_EXITING: u8 = 2;
-pub const OPERATOR_STATUS_SLASHED: u8 = 3;
-pub const OPERATOR_STATUS_JAILED: u8 = 4;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[fixed_offset_layout(buffer_offset = 0)]
 pub struct OperatorBond {
     /// Account type marker.
     pub discriminator: [u8; 8],
 
+    /// Canonical PDA bump for this account.
+    pub bump: u8,
+
     /// Operator identity allowed to post commitments through this bond.
     pub operator_identity: Pubkey,
 
     /// Slashable operator stake held in this account.
+    /// CHECKPOINT: the staking asset is SOL or BLOCK?
+    /// If this changes to BLOCK, this field will need to point at token-account
+    /// accounting instead of native lamports.
     pub stake_lamports: u64,
 
     /// Stake reserved by active commitments.
+    /// CHECKPOINT: the staking asset is SOL or BLOCK?
     pub locked_lamports: u64,
 
-    /// Current operator lifecycle state.
+    /// Current operator lifecycle state, stored as `OperatorStatus::value()`.
     pub status: u8,
 
     /// Slot when withdrawal was requested, if the operator is exiting.
@@ -31,4 +33,19 @@ pub struct OperatorBond {
 
 impl OperatorBond {
     pub const DISCRIMINATOR: [u8; 8] = *b"v2opbond";
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperatorStatus {
+    Active = 1,
+    Exiting = 2,
+    Slashed = 3,
+    Jailed = 4,
+}
+
+impl OperatorStatus {
+    pub const fn value(self) -> u8 {
+        self as u8
+    }
 }

--- a/src/v2/processor/bootstrap/mod.rs
+++ b/src/v2/processor/bootstrap/mod.rs
@@ -1,3 +1,5 @@
 mod init_protocol_config;
+mod register_operator;
 
 pub use init_protocol_config::*;
+pub use register_operator::*;

--- a/src/v2/processor/bootstrap/register_operator.rs
+++ b/src/v2/processor/bootstrap/register_operator.rs
@@ -1,0 +1,119 @@
+use dlp_api::{
+    error::DlpError,
+    v2::{
+        pda::{OPERATOR_BOND_SEED, PROTOCOL_CONFIG_SEED},
+        OperatorBond, ProtocolConfig, RegisterOperatorArgs,
+        OPERATOR_STATUS_ACTIVE,
+    },
+};
+use solana_sdk_ids::system_program;
+use solana_system_interface::instruction as system_instruction;
+
+use crate::{
+    processor::utils::{
+        loaders::{
+            load_initialized_pda, load_program, load_signer,
+            load_uninitialized_pda,
+        },
+        pda::create_pda,
+    },
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program::invoke,
+        program_error::ProgramError, pubkey::Pubkey,
+    },
+};
+
+/// Register one operator for v2 commitments.
+///
+/// Accounts:
+/// 0: `[signer, writable]` operator identity and stake payer
+/// 1: `[signer]`           protocol authority that admits the operator
+/// 2: `[writable]`         OperatorBond PDA
+/// 3: `[]`                 ProtocolConfig PDA
+/// 4: `[]`                 system program
+pub fn process_register_operator(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: &[u8],
+) -> ProgramResult {
+    let args = RegisterOperatorArgs::try_from_bytes(data)?;
+
+    let [operator, authority, operator_bond, protocol_config, system_program] =
+        accounts
+    else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    load_signer(operator, "operator")?;
+    load_signer(authority, "authority")?;
+    load_program(system_program, system_program::id(), "system program")?;
+
+    load_initialized_pda(
+        protocol_config,
+        &[PROTOCOL_CONFIG_SEED],
+        &crate::id(),
+        false,
+        "protocol config",
+    )?;
+
+    let protocol_config_data = protocol_config.try_borrow_data()?;
+    let protocol_config_state =
+        ProtocolConfig::try_from_bytes_with_discriminator(
+            protocol_config_data.as_ref(),
+        )?;
+
+    if protocol_config_state.authority != *authority.key {
+        return Err(DlpError::InvalidAuthority.into());
+    }
+
+    if *operator.key == Pubkey::default()
+        || args.amount_lamports < protocol_config_state.min_operator_bond
+    {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let operator_bond_bump = load_uninitialized_pda(
+        operator_bond,
+        &[OPERATOR_BOND_SEED, operator.key.as_ref()],
+        &crate::id(),
+        true,
+        "operator bond",
+    )?;
+
+    create_pda(
+        operator_bond,
+        &crate::id(),
+        OperatorBond::SPACE,
+        &[OPERATOR_BOND_SEED, operator.key.as_ref()],
+        operator_bond_bump,
+        system_program,
+        operator,
+    )?;
+
+    invoke(
+        &system_instruction::transfer(
+            operator.key,
+            operator_bond.key,
+            args.amount_lamports,
+        ),
+        &[
+            operator.clone(),
+            operator_bond.clone(),
+            system_program.clone(),
+        ],
+    )?;
+
+    let operator_bond_state = OperatorBond {
+        operator_identity: *operator.key,
+        stake_lamports: args.amount_lamports,
+        locked_lamports: 0,
+        status: OPERATOR_STATUS_ACTIVE,
+        withdraw_requested_slot: None,
+    };
+
+    let mut operator_bond_data = operator_bond.try_borrow_mut_data()?;
+    operator_bond_state
+        .to_bytes_with_discriminator(operator_bond_data.as_mut())?;
+
+    Ok(())
+}

--- a/src/v2/processor/bootstrap/register_operator.rs
+++ b/src/v2/processor/bootstrap/register_operator.rs
@@ -6,20 +6,23 @@ use dlp_api::{
         OPERATOR_STATUS_ACTIVE,
     },
 };
-use solana_sdk_ids::system_program;
-use solana_system_interface::instruction as system_instruction;
+use pinocchio::{
+    address::Address,
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    AccountView, ProgramResult,
+};
+use pinocchio_system::instructions as system;
+use wheels::{
+    layout::{Decodable, Encodable},
+    require_eq_keys, require_ge, require_n_accounts, require_ne,
+    require_signer,
+};
 
 use crate::{
-    processor::utils::{
-        loaders::{
-            load_initialized_pda, load_program, load_signer,
-            load_uninitialized_pda,
-        },
-        pda::create_pda,
-    },
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, program::invoke,
-        program_error::ProgramError, pubkey::Pubkey,
+    processor::fast::utils::pda::create_pda,
+    requires::{
+        require_initialized_pda, require_uninitialized_pda, StandardCtx,
     },
 };
 
@@ -30,90 +33,91 @@ use crate::{
 /// 1: `[signer]`           protocol authority that admits the operator
 /// 2: `[writable]`         OperatorBond PDA
 /// 3: `[]`                 ProtocolConfig PDA
-/// 4: `[]`                 system program
+/// 4: `[]`                 system program, required by system CPI
+#[inline(never)]
 pub fn process_register_operator(
-    _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountView],
     data: &[u8],
 ) -> ProgramResult {
-    let args = RegisterOperatorArgs::try_from_bytes(data)?;
+    let [
+        operator, // force multi-line
+        authority,
+        operator_bond,
+        protocol_config,
+        _system_program,
+    ] = require_n_accounts!(accounts, 5);
 
-    let [operator, authority, operator_bond, protocol_config, system_program] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = RegisterOperatorArgs::decode(data)?;
 
-    load_signer(operator, "operator")?;
-    load_signer(authority, "authority")?;
-    load_program(system_program, system_program::id(), "system program")?;
+    require_signer!(operator);
+    require_signer!(authority);
 
-    load_initialized_pda(
+    require_initialized_pda(
         protocol_config,
         &[PROTOCOL_CONFIG_SEED],
-        &crate::id(),
+        &crate::fast::ID,
         false,
         "protocol config",
     )?;
-
-    let protocol_config_data = protocol_config.try_borrow_data()?;
+    let protocol_config_data = protocol_config.try_borrow()?;
     let protocol_config_state =
-        ProtocolConfig::try_from_bytes_with_discriminator(
-            protocol_config_data.as_ref(),
-        )?;
-
-    if protocol_config_state.authority != *authority.key {
-        return Err(DlpError::InvalidAuthority.into());
+        ProtocolConfig::decode(protocol_config_data.as_ref())?;
+    if protocol_config_state.discriminator() != ProtocolConfig::DISCRIMINATOR {
+        return Err(ProgramError::InvalidAccountData);
     }
+    require_eq_keys!(
+        &Address::from(protocol_config_state.authority().to_bytes()),
+        authority.address(),
+        DlpError::InvalidAuthority
+    );
+    require_ne!(
+        args.amount_lamports(),
+        0,
+        ProgramError::InvalidInstructionData
+    );
+    require_ge!(
+        args.amount_lamports(),
+        protocol_config_state.min_operator_bond(),
+        ProgramError::InvalidInstructionData
+    );
+    drop(protocol_config_data);
 
-    if *operator.key == Pubkey::default()
-        || args.amount_lamports < protocol_config_state.min_operator_bond
-    {
-        return Err(ProgramError::InvalidInstructionData);
-    }
-
-    let operator_bond_bump = load_uninitialized_pda(
+    let operator_bond_bump = require_uninitialized_pda(
         operator_bond,
-        &[OPERATOR_BOND_SEED, operator.key.as_ref()],
-        &crate::id(),
+        &[OPERATOR_BOND_SEED, operator.address().as_ref()],
+        &crate::fast::ID,
         true,
-        "operator bond",
+        StandardCtx::new("operator bond"),
     )?;
 
     create_pda(
         operator_bond,
-        &crate::id(),
-        OperatorBond::SPACE,
-        &[OPERATOR_BOND_SEED, operator.key.as_ref()],
-        operator_bond_bump,
-        system_program,
+        &crate::fast::ID,
+        OperatorBond::DATA_LEN,
+        &[Signer::from(&[
+            Seed::from(OPERATOR_BOND_SEED),
+            Seed::from(operator.address().as_ref()),
+            Seed::from(&[operator_bond_bump]),
+        ])],
         operator,
     )?;
 
-    invoke(
-        &system_instruction::transfer(
-            operator.key,
-            operator_bond.key,
-            args.amount_lamports,
-        ),
-        &[
-            operator.clone(),
-            operator_bond.clone(),
-            system_program.clone(),
-        ],
-    )?;
+    system::Transfer {
+        from: operator,
+        to: operator_bond,
+        lamports: args.amount_lamports(),
+    }
+    .invoke()?;
 
-    let operator_bond_state = OperatorBond {
-        operator_identity: *operator.key,
-        stake_lamports: args.amount_lamports,
+    OperatorBond {
+        discriminator: OperatorBond::DISCRIMINATOR,
+        operator_identity: operator.address().to_bytes().into(),
+        stake_lamports: args.amount_lamports(),
         locked_lamports: 0,
         status: OPERATOR_STATUS_ACTIVE,
         withdraw_requested_slot: None,
-    };
-
-    let mut operator_bond_data = operator_bond.try_borrow_mut_data()?;
-    operator_bond_state
-        .to_bytes_with_discriminator(operator_bond_data.as_mut())?;
+    }
+    .encode_to(operator_bond.try_borrow_mut()?.as_mut())?;
 
     Ok(())
 }

--- a/src/v2/processor/bootstrap/register_operator.rs
+++ b/src/v2/processor/bootstrap/register_operator.rs
@@ -2,12 +2,10 @@ use dlp_api::{
     error::DlpError,
     v2::{
         pda::{OPERATOR_BOND_SEED, PROTOCOL_CONFIG_SEED},
-        OperatorBond, ProtocolConfig, RegisterOperatorArgs,
-        OPERATOR_STATUS_ACTIVE,
+        OperatorBond, OperatorStatus, ProtocolConfig, RegisterOperatorArgs,
     },
 };
 use pinocchio::{
-    address::Address,
     cpi::{Seed, Signer},
     error::ProgramError,
     AccountView, ProgramResult,
@@ -15,8 +13,7 @@ use pinocchio::{
 use pinocchio_system::instructions as system;
 use wheels::{
     layout::{Decodable, Encodable},
-    require_eq_keys, require_ge, require_n_accounts, require_ne,
-    require_signer,
+    require, require_eq_keys, require_ge, require_n_accounts, require_signer,
 };
 
 use crate::{
@@ -47,10 +44,10 @@ pub fn process_register_operator(
         _system_program,
     ] = require_n_accounts!(accounts, 5);
 
-    let args = RegisterOperatorArgs::decode(data)?;
-
     require_signer!(operator);
     require_signer!(authority);
+
+    let args = RegisterOperatorArgs::decode(data)?;
 
     require_initialized_pda(
         protocol_config,
@@ -62,24 +59,22 @@ pub fn process_register_operator(
     let protocol_config_data = protocol_config.try_borrow()?;
     let protocol_config_state =
         ProtocolConfig::decode(protocol_config_data.as_ref())?;
-    if protocol_config_state.discriminator() != ProtocolConfig::DISCRIMINATOR {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        protocol_config_state.discriminator() == ProtocolConfig::DISCRIMINATOR,
+        ProgramError::InvalidAccountData
+    );
+
     require_eq_keys!(
-        &Address::from(protocol_config_state.authority().to_bytes()),
+        protocol_config_state.authority(),
         authority.address(),
         DlpError::InvalidAuthority
     );
-    require_ne!(
-        args.amount_lamports(),
-        0,
-        ProgramError::InvalidInstructionData
-    );
     require_ge!(
-        args.amount_lamports(),
+        args.stake_lamports(),
         protocol_config_state.min_operator_bond(),
         ProgramError::InvalidInstructionData
     );
+
     drop(protocol_config_data);
 
     let operator_bond_bump = require_uninitialized_pda(
@@ -105,16 +100,17 @@ pub fn process_register_operator(
     system::Transfer {
         from: operator,
         to: operator_bond,
-        lamports: args.amount_lamports(),
+        lamports: args.stake_lamports(),
     }
     .invoke()?;
 
     OperatorBond {
         discriminator: OperatorBond::DISCRIMINATOR,
+        bump: operator_bond_bump,
         operator_identity: operator.address().to_bytes().into(),
-        stake_lamports: args.amount_lamports(),
+        stake_lamports: args.stake_lamports(),
         locked_lamports: 0,
-        status: OPERATOR_STATUS_ACTIVE,
+        status: OperatorStatus::Active.value(),
         withdraw_requested_slot: None,
     }
     .encode_to(operator_bond.try_borrow_mut()?.as_mut())?;

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -16,5 +16,8 @@ pub fn process_instruction(
         DlpV2Instruction::InitProtocolConfig => {
             process_init_protocol_config(accounts, data)
         }
+        DlpV2Instruction::RegisterOperator => {
+            process_register_operator(program_id, accounts, data)
+        }
     }
 }

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -17,7 +17,7 @@ pub fn process_instruction(
             process_init_protocol_config(accounts, data)
         }
         DlpV2Instruction::RegisterOperator => {
-            process_register_operator(program_id, accounts, data)
+            process_register_operator(accounts, data)
         }
     }
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -1,4 +1,5 @@
 pub mod accounts;
+pub mod v2;
 
 #[allow(unused_imports)]
 pub(crate) use accounts::*;

--- a/tests/fixtures/v2.rs
+++ b/tests/fixtures/v2.rs
@@ -1,0 +1,69 @@
+use dlp_api::v2::{
+    instruction_builder::init_protocol_config, InitProtocolConfigArgs,
+};
+use solana_program::{
+    hash::Hash, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey,
+};
+use solana_program_test::{BanksClient, ProgramTest};
+use solana_sdk::{
+    account::Account,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use solana_sdk_ids::system_program;
+
+pub fn valid_args() -> InitProtocolConfigArgs {
+    InitProtocolConfigArgs {
+        resolver: Pubkey::new_unique(),
+        min_operator_bond: 1,
+        min_verifier_bond: 1,
+        min_challenger_stake: 1,
+        challenge_window_slots: 10,
+        operator_response_timeout_slots: 10,
+        challenger_reveal_timeout_slots: 10,
+        payout_timelock_slots: 10,
+        verifiers_per_commitment: 1,
+        approval_threshold: 1,
+        max_window_extensions: 1,
+        match_penalty_bps: 500,
+    }
+}
+
+#[allow(dead_code)]
+pub async fn init_v2(
+    banks: &BanksClient,
+    payer: &Keypair,
+    authority: &Keypair,
+    blockhash: Hash,
+    args: InitProtocolConfigArgs,
+) {
+    let ix = init_protocol_config(authority.pubkey(), args);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer, authority],
+        blockhash,
+    );
+
+    banks.process_transaction(tx).await.unwrap();
+}
+
+pub async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
+    let mut program_test = ProgramTest::new("dlp", dlp_api::ID, None);
+    program_test.prefer_bpf(true);
+
+    let authority = Keypair::new();
+    program_test.add_account(
+        authority.pubkey(),
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: vec![],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (banks, payer, blockhash) = program_test.start().await;
+    (banks, payer, authority, blockhash)
+}

--- a/tests/fixtures/v2.rs
+++ b/tests/fixtures/v2.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
 };
 use solana_sdk_ids::system_program;
 
-pub fn valid_args() -> InitProtocolConfigArgs {
+pub fn valid_protocol_config_args() -> InitProtocolConfigArgs {
     InitProtocolConfigArgs {
         resolver: Pubkey::new_unique(),
         min_operator_bond: 1,
@@ -30,7 +30,7 @@ pub fn valid_args() -> InitProtocolConfigArgs {
 }
 
 #[allow(dead_code)]
-pub async fn init_v2(
+pub async fn initialize_protocol_config(
     banks: &BanksClient,
     payer: &Keypair,
     authority: &Keypair,

--- a/tests/test_v2_init_protocol_config.rs
+++ b/tests/test_v2_init_protocol_config.rs
@@ -14,13 +14,13 @@ use wheels::layout::Decodable;
 
 mod fixtures;
 
-use crate::fixtures::v2::{setup_program_test_env, valid_args};
+use crate::fixtures::v2::{setup_program_test_env, valid_protocol_config_args};
 
 #[tokio::test]
 async fn test_init_protocol_config() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let args = valid_args();
+    let args = valid_protocol_config_args();
     let ix = init_protocol_config(authority.pubkey(), args.clone());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -109,7 +109,8 @@ async fn test_init_protocol_config() {
 async fn test_init_protocol_config_fails_twice() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let ix = init_protocol_config(authority.pubkey(), valid_args());
+    let ix =
+        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -119,7 +120,8 @@ async fn test_init_protocol_config_fails_twice() {
     banks.process_transaction(tx).await.unwrap();
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
-    let ix = init_protocol_config(authority.pubkey(), valid_args());
+    let ix =
+        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -134,7 +136,8 @@ async fn test_init_protocol_config_fails_twice() {
 async fn test_init_protocol_config_fails_with_wrong_protocol_config_pda() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
+    let mut ix =
+        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
     ix.accounts[1].pubkey = Pubkey::new_unique();
 
     let tx = Transaction::new_signed_with_payer(
@@ -151,7 +154,8 @@ async fn test_init_protocol_config_fails_with_wrong_protocol_config_pda() {
 async fn test_init_protocol_config_fails_with_wrong_verifier_registry_pda() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
+    let mut ix =
+        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
     ix.accounts[2].pubkey = Pubkey::new_unique();
 
     let tx = Transaction::new_signed_with_payer(
@@ -168,7 +172,8 @@ async fn test_init_protocol_config_fails_with_wrong_verifier_registry_pda() {
 async fn test_init_protocol_config_fails_without_authority_signature() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
+    let mut ix =
+        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
     ix.accounts[0].is_signer = false;
 
     let tx = Transaction::new_signed_with_payer(
@@ -185,7 +190,7 @@ async fn test_init_protocol_config_fails_without_authority_signature() {
 async fn test_init_protocol_config_fails_with_invalid_args() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_args();
+    let mut args = valid_protocol_config_args();
     args.approval_threshold = args.verifiers_per_commitment + 1;
 
     let ix = init_protocol_config(authority.pubkey(), args);
@@ -203,7 +208,7 @@ async fn test_init_protocol_config_fails_with_invalid_args() {
 async fn test_init_protocol_config_fails_with_zero_verifier_cap() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_args();
+    let mut args = valid_protocol_config_args();
     args.verifiers_per_commitment = 0;
 
     let ix = init_protocol_config(authority.pubkey(), args);
@@ -221,7 +226,7 @@ async fn test_init_protocol_config_fails_with_zero_verifier_cap() {
 async fn test_init_protocol_config_fails_with_zero_approval_threshold() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_args();
+    let mut args = valid_protocol_config_args();
     args.approval_threshold = 0;
 
     let ix = init_protocol_config(authority.pubkey(), args);

--- a/tests/test_v2_init_protocol_config.rs
+++ b/tests/test_v2_init_protocol_config.rs
@@ -1,4 +1,3 @@
-use dlp::solana_program;
 use dlp_api::{
     pda::fees_vault_pda,
     v2::{
@@ -7,27 +6,21 @@ use dlp_api::{
             protocol_config_pda, verifier_registry_pda, PROTOCOL_CONFIG_SEED,
             VERIFIER_REGISTRY_SEED,
         },
-        InitProtocolConfigArgs, ProtocolConfig, VerifierRegistry,
+        ProtocolConfig, VerifierRegistry,
     },
 };
-use solana_program::{hash::Hash, native_token::LAMPORTS_PER_SOL};
-use solana_program_test::{BanksClient, ProgramTest};
-use solana_sdk::{
-    account::Account,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use solana_sdk_ids::system_program;
+use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use wheels::layout::Decodable;
 
 mod fixtures;
+
+use crate::fixtures::v2::{setup_program_test_env, valid_args};
 
 #[tokio::test]
 async fn test_init_protocol_config() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let args = valid_protocol_config_args();
+    let args = valid_args();
     let ix = init_protocol_config(authority.pubkey(), args.clone());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -116,8 +109,7 @@ async fn test_init_protocol_config() {
 async fn test_init_protocol_config_fails_twice() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let ix =
-        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
+    let ix = init_protocol_config(authority.pubkey(), valid_args());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -127,8 +119,7 @@ async fn test_init_protocol_config_fails_twice() {
     banks.process_transaction(tx).await.unwrap();
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
-    let ix =
-        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
+    let ix = init_protocol_config(authority.pubkey(), valid_args());
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -143,9 +134,7 @@ async fn test_init_protocol_config_fails_twice() {
 async fn test_init_protocol_config_fails_with_wrong_protocol_config_pda() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix =
-        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
-
+    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
     ix.accounts[1].pubkey = Pubkey::new_unique();
 
     let tx = Transaction::new_signed_with_payer(
@@ -162,9 +151,7 @@ async fn test_init_protocol_config_fails_with_wrong_protocol_config_pda() {
 async fn test_init_protocol_config_fails_with_wrong_verifier_registry_pda() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix =
-        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
-
+    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
     ix.accounts[2].pubkey = Pubkey::new_unique();
 
     let tx = Transaction::new_signed_with_payer(
@@ -181,9 +168,7 @@ async fn test_init_protocol_config_fails_with_wrong_verifier_registry_pda() {
 async fn test_init_protocol_config_fails_without_authority_signature() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut ix =
-        init_protocol_config(authority.pubkey(), valid_protocol_config_args());
-
+    let mut ix = init_protocol_config(authority.pubkey(), valid_args());
     ix.accounts[0].is_signer = false;
 
     let tx = Transaction::new_signed_with_payer(
@@ -200,8 +185,7 @@ async fn test_init_protocol_config_fails_without_authority_signature() {
 async fn test_init_protocol_config_fails_with_invalid_args() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_protocol_config_args();
-
+    let mut args = valid_args();
     args.approval_threshold = args.verifiers_per_commitment + 1;
 
     let ix = init_protocol_config(authority.pubkey(), args);
@@ -219,8 +203,7 @@ async fn test_init_protocol_config_fails_with_invalid_args() {
 async fn test_init_protocol_config_fails_with_zero_verifier_cap() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_protocol_config_args();
-
+    let mut args = valid_args();
     args.verifiers_per_commitment = 0;
 
     let ix = init_protocol_config(authority.pubkey(), args);
@@ -238,8 +221,7 @@ async fn test_init_protocol_config_fails_with_zero_verifier_cap() {
 async fn test_init_protocol_config_fails_with_zero_approval_threshold() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    let mut args = valid_protocol_config_args();
-
+    let mut args = valid_args();
     args.approval_threshold = 0;
 
     let ix = init_protocol_config(authority.pubkey(), args);
@@ -251,41 +233,4 @@ async fn test_init_protocol_config_fails_with_zero_approval_threshold() {
     );
 
     assert!(banks.process_transaction(tx).await.is_err());
-}
-
-fn valid_protocol_config_args() -> InitProtocolConfigArgs {
-    InitProtocolConfigArgs {
-        resolver: Pubkey::new_unique(),
-        min_operator_bond: 1,
-        min_verifier_bond: 1,
-        min_challenger_stake: 1,
-        challenge_window_slots: 10,
-        operator_response_timeout_slots: 10,
-        challenger_reveal_timeout_slots: 10,
-        payout_timelock_slots: 10,
-        verifiers_per_commitment: 1,
-        approval_threshold: 1,
-        max_window_extensions: 1,
-        match_penalty_bps: 500,
-    }
-}
-
-async fn setup_program_test_env() -> (BanksClient, Keypair, Keypair, Hash) {
-    let mut program_test = ProgramTest::new("dlp", dlp_api::ID, None);
-    program_test.prefer_bpf(true);
-
-    let authority = Keypair::new();
-    program_test.add_account(
-        authority.pubkey(),
-        Account {
-            lamports: LAMPORTS_PER_SOL,
-            data: vec![],
-            owner: system_program::id(),
-            executable: false,
-            rent_epoch: 0,
-        },
-    );
-
-    let (banks, payer, blockhash) = program_test.start().await;
-    (banks, payer, authority, blockhash)
 }

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -1,19 +1,42 @@
 use dlp_api::v2::{
     instruction_builder::register_operator, pda::operator_bond_pda,
-    OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
+    DlpV2Instruction, OperatorBond, RegisterOperatorArgs,
+    OPERATOR_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 use solana_system_interface::instruction as system_instruction;
-use wheels::layout::Decodable;
+use wheels::layout::{Decodable, Encodable};
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[test]
+fn test_v2_register_operator_instruction_data_uses_one_byte_tag() {
+    let args = RegisterOperatorArgs {
+        amount_lamports: 42,
+    };
+    let ix = register_operator(
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        args.clone(),
+    );
+    let encoded_args = args.encode().unwrap();
+
+    assert_eq!(ix.data[0], DlpV2Instruction::RegisterOperator as u8);
+    assert_eq!(ix.data.len(), 1 + encoded_args.len());
+    assert_eq!(&ix.data[1..], encoded_args.as_slice());
+
+    let decoded =
+        <RegisterOperatorArgs as Decodable>::decode(&ix.data[1..]).unwrap();
+    assert_eq!(decoded.amount_lamports(), args.amount_lamports);
+}
 
 #[tokio::test]
 async fn test_v2_register_operator() {

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -3,6 +3,7 @@ use dlp_api::v2::{
     OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
@@ -119,7 +120,8 @@ async fn test_v2_register_operator_fails_with_low_stake() {
 
 #[tokio::test]
 async fn test_v2_register_operator_fails_twice() {
-    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let (mut banks, payer, authority, blockhash) =
+        setup_program_test_env().await;
     let config_args = valid_args();
     let operator = Keypair::new();
 
@@ -133,7 +135,11 @@ async fn test_v2_register_operator_fails_twice() {
             amount_lamports: config_args.min_operator_bond,
         },
     );
-    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+    let blockhash = banks
+        .get_new_latest_blockhash(&latest_blockhash)
+        .await
+        .unwrap();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -149,7 +155,11 @@ async fn test_v2_register_operator_fails_twice() {
             amount_lamports: config_args.min_operator_bond,
         },
     );
-    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+    let blockhash = banks
+        .get_new_latest_blockhash(&latest_blockhash)
+        .await
+        .unwrap();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -13,15 +13,25 @@ use wheels::layout::Decodable;
 
 mod fixtures;
 
-use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+use crate::fixtures::v2::{
+    initialize_protocol_config, setup_program_test_env,
+    valid_protocol_config_args,
+};
 
 #[tokio::test]
-async fn test_v2_register_operator() {
+async fn test_register_operator() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let operator = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_operator(&banks, &payer, &operator).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
@@ -66,12 +76,19 @@ async fn test_v2_register_operator() {
 }
 
 #[tokio::test]
-async fn test_v2_register_operator_fails_with_wrong_authority() {
+async fn test_register_operator_fails_with_wrong_authority() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let operator = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_operator(&banks, &payer, &operator).await;
 
     let wrong_authority = Keypair::new();
@@ -94,12 +111,19 @@ async fn test_v2_register_operator_fails_with_wrong_authority() {
 }
 
 #[tokio::test]
-async fn test_v2_register_operator_fails_with_low_stake() {
+async fn test_register_operator_fails_with_low_stake() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let operator = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args,
+    )
+    .await;
     fund_operator(&banks, &payer, &operator).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
@@ -119,13 +143,20 @@ async fn test_v2_register_operator_fails_with_low_stake() {
 }
 
 #[tokio::test]
-async fn test_v2_register_operator_fails_twice() {
+async fn test_register_operator_fails_twice() {
     let (mut banks, payer, authority, blockhash) =
         setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let operator = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_operator(&banks, &payer, &operator).await;
 
     let ix = register_operator(

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -1,8 +1,10 @@
 use dlp_api::v2::{
-    instruction_builder::register_operator, pda::operator_bond_pda,
-    OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
+    instruction_builder::register_operator, pda::OPERATOR_BOND_SEED,
+    OperatorBond, OperatorStatus, RegisterOperatorArgs,
 };
-use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_program::{
+    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, rent::Rent,
+};
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
     signature::{Keypair, Signer},
@@ -23,6 +25,11 @@ async fn test_register_operator() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_protocol_config_args();
     let operator = Keypair::new();
+    let (operator_bond_address, expected_operator_bond_bump) =
+        Pubkey::find_program_address(
+            &[OPERATOR_BOND_SEED, operator.pubkey().as_ref()],
+            &dlp_api::id(),
+        );
 
     initialize_protocol_config(
         &banks,
@@ -39,7 +46,7 @@ async fn test_register_operator() {
         operator.pubkey(),
         authority.pubkey(),
         RegisterOperatorArgs {
-            amount_lamports: config_args.min_operator_bond,
+            stake_lamports: config_args.min_operator_bond,
         },
     );
     let tx = Transaction::new_signed_with_payer(
@@ -52,26 +59,29 @@ async fn test_register_operator() {
     assert!(banks.process_transaction(tx).await.is_ok());
 
     let operator_bond_account = banks
-        .get_account(operator_bond_pda(&operator.pubkey()))
+        .get_account(operator_bond_address)
         .await
         .unwrap()
         .unwrap();
     let operator_bond =
-        <OperatorBond as Decodable>::decode(&operator_bond_account.data)
-            .unwrap();
+        OperatorBond::decode(&operator_bond_account.data).unwrap();
+    let expected_operator_bond_lamports = Rent::default()
+        .minimum_balance(OperatorBond::DATA_LEN)
+        + config_args.min_operator_bond;
 
     assert_eq!(operator_bond.discriminator(), OperatorBond::DISCRIMINATOR);
+    assert_eq!(operator_bond.bump(), expected_operator_bond_bump);
     assert_eq!(*operator_bond.operator_identity(), operator.pubkey());
     assert_eq!(
         operator_bond.stake_lamports(),
         config_args.min_operator_bond
     );
     assert_eq!(operator_bond.locked_lamports(), 0);
-    assert_eq!(operator_bond.status(), OPERATOR_STATUS_ACTIVE);
+    assert_eq!(operator_bond.status(), OperatorStatus::Active.value());
     assert_eq!(operator_bond.withdraw_requested_slot(), None);
-    assert!(
-        operator_bond_account.lamports > operator_bond.stake_lamports(),
-        "operator bond account should hold rent plus stake"
+    assert_eq!(
+        operator_bond_account.lamports,
+        expected_operator_bond_lamports
     );
 }
 
@@ -97,7 +107,7 @@ async fn test_register_operator_fails_with_wrong_authority() {
         operator.pubkey(),
         wrong_authority.pubkey(),
         RegisterOperatorArgs {
-            amount_lamports: config_args.min_operator_bond,
+            stake_lamports: config_args.min_operator_bond,
         },
     );
     let tx = Transaction::new_signed_with_payer(
@@ -130,7 +140,7 @@ async fn test_register_operator_fails_with_low_stake() {
     let ix = register_operator(
         operator.pubkey(),
         authority.pubkey(),
-        RegisterOperatorArgs { amount_lamports: 0 },
+        RegisterOperatorArgs { stake_lamports: 0 },
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -159,46 +169,50 @@ async fn test_register_operator_fails_twice() {
     .await;
     fund_operator(&banks, &payer, &operator).await;
 
-    let ix = register_operator(
-        operator.pubkey(),
-        authority.pubkey(),
-        RegisterOperatorArgs {
-            amount_lamports: config_args.min_operator_bond,
-        },
-    );
-    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
-    let blockhash = banks
-        .get_new_latest_blockhash(&latest_blockhash)
-        .await
-        .unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&payer.pubkey()),
-        &[&payer, &operator, &authority],
-        blockhash,
-    );
-    banks.process_transaction(tx).await.unwrap();
+    {
+        let ix = register_operator(
+            operator.pubkey(),
+            authority.pubkey(),
+            RegisterOperatorArgs {
+                stake_lamports: config_args.min_operator_bond,
+            },
+        );
+        let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+        let blockhash = banks
+            .get_new_latest_blockhash(&latest_blockhash)
+            .await
+            .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&payer.pubkey()),
+            &[&payer, &operator, &authority],
+            blockhash,
+        );
+        banks.process_transaction(tx).await.unwrap();
+    }
 
-    let ix = register_operator(
-        operator.pubkey(),
-        authority.pubkey(),
-        RegisterOperatorArgs {
-            amount_lamports: config_args.min_operator_bond,
-        },
-    );
-    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
-    let blockhash = banks
-        .get_new_latest_blockhash(&latest_blockhash)
-        .await
-        .unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&payer.pubkey()),
-        &[&payer, &operator, &authority],
-        blockhash,
-    );
+    {
+        let ix = register_operator(
+            operator.pubkey(),
+            authority.pubkey(),
+            RegisterOperatorArgs {
+                stake_lamports: config_args.min_operator_bond,
+            },
+        );
+        let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+        let blockhash = banks
+            .get_new_latest_blockhash(&latest_blockhash)
+            .await
+            .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&payer.pubkey()),
+            &[&payer, &operator, &authority],
+            blockhash,
+        );
 
-    assert!(banks.process_transaction(tx).await.is_err());
+        assert!(banks.process_transaction(tx).await.is_err());
+    }
 }
 
 async fn fund_operator(

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -1,0 +1,147 @@
+use dlp_api::v2::{
+    instruction_builder::register_operator, pda::operator_bond_pda,
+    OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
+};
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod fixtures;
+
+use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[tokio::test]
+async fn test_v2_register_operator() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_operator(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterOperatorArgs {
+            amount_lamports: config_args.min_operator_bond,
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_ok());
+
+    let operator_bond_account = banks
+        .get_account(operator_bond_pda(&payer.pubkey()))
+        .await
+        .unwrap()
+        .unwrap();
+    let operator_bond = OperatorBond::try_from_bytes_with_discriminator(
+        &operator_bond_account.data,
+    )
+    .unwrap();
+
+    assert_eq!(operator_bond.operator_identity, payer.pubkey());
+    assert_eq!(operator_bond.stake_lamports, config_args.min_operator_bond);
+    assert_eq!(operator_bond.locked_lamports, 0);
+    assert_eq!(operator_bond.status, OPERATOR_STATUS_ACTIVE);
+    assert_eq!(operator_bond.withdraw_requested_slot, None);
+    assert!(
+        operator_bond_account.lamports > operator_bond.stake_lamports,
+        "operator bond account should hold rent plus stake"
+    );
+}
+
+#[tokio::test]
+async fn test_v2_register_operator_fails_with_wrong_authority() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let wrong_authority = Keypair::new();
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_operator(
+        payer.pubkey(),
+        wrong_authority.pubkey(),
+        RegisterOperatorArgs {
+            amount_lamports: config_args.min_operator_bond,
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &wrong_authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_register_operator_fails_with_low_stake() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_operator(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterOperatorArgs { amount_lamports: 0 },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_register_operator_fails_twice() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let ix = register_operator(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterOperatorArgs {
+            amount_lamports: config_args.min_operator_bond,
+        },
+    );
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+    banks.process_transaction(tx).await.unwrap();
+
+    let ix = register_operator(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterOperatorArgs {
+            amount_lamports: config_args.min_operator_bond,
+        },
+    );
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -2,10 +2,13 @@ use dlp_api::v2::{
     instruction_builder::register_operator, pda::operator_bond_pda,
     OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
 };
+use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+use solana_system_interface::instruction as system_instruction;
+use wheels::layout::Decodable;
 
 mod fixtures;
 
@@ -15,12 +18,14 @@ use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
 async fn test_v2_register_operator() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let operator = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_operator(&banks, &payer, &operator).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_operator(
-        payer.pubkey(),
+        operator.pubkey(),
         authority.pubkey(),
         RegisterOperatorArgs {
             amount_lamports: config_args.min_operator_bond,
@@ -29,29 +34,32 @@ async fn test_v2_register_operator() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &operator, &authority],
         blockhash,
     );
 
     assert!(banks.process_transaction(tx).await.is_ok());
 
     let operator_bond_account = banks
-        .get_account(operator_bond_pda(&payer.pubkey()))
+        .get_account(operator_bond_pda(&operator.pubkey()))
         .await
         .unwrap()
         .unwrap();
-    let operator_bond = OperatorBond::try_from_bytes_with_discriminator(
-        &operator_bond_account.data,
-    )
-    .unwrap();
+    let operator_bond =
+        <OperatorBond as Decodable>::decode(&operator_bond_account.data)
+            .unwrap();
 
-    assert_eq!(operator_bond.operator_identity, payer.pubkey());
-    assert_eq!(operator_bond.stake_lamports, config_args.min_operator_bond);
-    assert_eq!(operator_bond.locked_lamports, 0);
-    assert_eq!(operator_bond.status, OPERATOR_STATUS_ACTIVE);
-    assert_eq!(operator_bond.withdraw_requested_slot, None);
+    assert_eq!(operator_bond.discriminator(), OperatorBond::DISCRIMINATOR);
+    assert_eq!(*operator_bond.operator_identity(), operator.pubkey());
+    assert_eq!(
+        operator_bond.stake_lamports(),
+        config_args.min_operator_bond
+    );
+    assert_eq!(operator_bond.locked_lamports(), 0);
+    assert_eq!(operator_bond.status(), OPERATOR_STATUS_ACTIVE);
+    assert_eq!(operator_bond.withdraw_requested_slot(), None);
     assert!(
-        operator_bond_account.lamports > operator_bond.stake_lamports,
+        operator_bond_account.lamports > operator_bond.stake_lamports(),
         "operator bond account should hold rent plus stake"
     );
 }
@@ -60,13 +68,15 @@ async fn test_v2_register_operator() {
 async fn test_v2_register_operator_fails_with_wrong_authority() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let operator = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_operator(&banks, &payer, &operator).await;
 
     let wrong_authority = Keypair::new();
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_operator(
-        payer.pubkey(),
+        operator.pubkey(),
         wrong_authority.pubkey(),
         RegisterOperatorArgs {
             amount_lamports: config_args.min_operator_bond,
@@ -75,7 +85,7 @@ async fn test_v2_register_operator_fails_with_wrong_authority() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &wrong_authority],
+        &[&payer, &operator, &wrong_authority],
         blockhash,
     );
 
@@ -86,19 +96,21 @@ async fn test_v2_register_operator_fails_with_wrong_authority() {
 async fn test_v2_register_operator_fails_with_low_stake() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let operator = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+    fund_operator(&banks, &payer, &operator).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_operator(
-        payer.pubkey(),
+        operator.pubkey(),
         authority.pubkey(),
         RegisterOperatorArgs { amount_lamports: 0 },
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &operator, &authority],
         blockhash,
     );
 
@@ -109,11 +121,13 @@ async fn test_v2_register_operator_fails_with_low_stake() {
 async fn test_v2_register_operator_fails_twice() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let operator = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_operator(&banks, &payer, &operator).await;
 
     let ix = register_operator(
-        payer.pubkey(),
+        operator.pubkey(),
         authority.pubkey(),
         RegisterOperatorArgs {
             amount_lamports: config_args.min_operator_bond,
@@ -123,13 +137,13 @@ async fn test_v2_register_operator_fails_twice() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &operator, &authority],
         blockhash,
     );
     banks.process_transaction(tx).await.unwrap();
 
     let ix = register_operator(
-        payer.pubkey(),
+        operator.pubkey(),
         authority.pubkey(),
         RegisterOperatorArgs {
             amount_lamports: config_args.min_operator_bond,
@@ -139,9 +153,30 @@ async fn test_v2_register_operator_fails_twice() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &operator, &authority],
         blockhash,
     );
 
     assert!(banks.process_transaction(tx).await.is_err());
+}
+
+async fn fund_operator(
+    banks: &solana_program_test::BanksClient,
+    payer: &Keypair,
+    operator: &Keypair,
+) {
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = system_instruction::transfer(
+        &payer.pubkey(),
+        &operator.pubkey(),
+        LAMPORTS_PER_SOL,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        blockhash,
+    );
+
+    banks.process_transaction(tx).await.unwrap();
 }

--- a/tests/test_v2_register_operator.rs
+++ b/tests/test_v2_register_operator.rs
@@ -1,42 +1,19 @@
 use dlp_api::v2::{
     instruction_builder::register_operator, pda::operator_bond_pda,
-    DlpV2Instruction, OperatorBond, RegisterOperatorArgs,
-    OPERATOR_STATUS_ACTIVE,
+    OperatorBond, RegisterOperatorArgs, OPERATOR_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 use solana_system_interface::instruction as system_instruction;
-use wheels::layout::{Decodable, Encodable};
+use wheels::layout::Decodable;
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
-
-#[test]
-fn test_v2_register_operator_instruction_data_uses_one_byte_tag() {
-    let args = RegisterOperatorArgs {
-        amount_lamports: 42,
-    };
-    let ix = register_operator(
-        Pubkey::new_unique(),
-        Pubkey::new_unique(),
-        args.clone(),
-    );
-    let encoded_args = args.encode().unwrap();
-
-    assert_eq!(ix.data[0], DlpV2Instruction::RegisterOperator as u8);
-    assert_eq!(ix.data.len(), 1 + encoded_args.len());
-    assert_eq!(&ix.data[1..], encoded_args.as_slice());
-
-    let decoded =
-        <RegisterOperatorArgs as Decodable>::decode(&ix.data[1..]).unwrap();
-    assert_eq!(decoded.amount_lamports(), args.amount_lamports);
-}
 
 #[tokio::test]
 async fn test_v2_register_operator() {


### PR DESCRIPTION
Implements the DLP v2 bootstrap instruction `RegisterOperator`, which creates the operator bond account and locks the operator’s initial stake under the configured protocol authority.

Closes #207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator registration for DLP v2 with an initial stake deposit.
  * Added operator bond tracking for stake, locked funds, withdrawal requests, and lifecycle status.
  * Added validation for authority, minimum stake, duplicate registration, and required account details.
  * Added support for deriving operator-specific bond accounts.

* **Tests**
  * Added integration coverage for successful registration and key validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->