### PR TITLE
feat(fraud-proofs): Implement RegisterVerifier

### DIFF
--- a/dlp-api/src/v2/args/mod.rs
+++ b/dlp-api/src/v2/args/mod.rs
@@ -3,6 +3,8 @@
 
 mod init_protocol_config;
 mod register_operator;
+mod register_verifier;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
+pub use register_verifier::*;

--- a/dlp-api/src/v2/args/register_verifier.rs
+++ b/dlp-api/src/v2/args/register_verifier.rs
@@ -1,20 +1,7 @@
-use wheels::{layout::Decodable, variable_offset_layout};
-
-use crate::solana_program::program_error::ProgramError;
+use wheels::variable_offset_layout;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[variable_offset_layout(buffer_offset = unaligned)]
+#[variable_offset_layout(buffer_offset = 0)]
 pub struct RegisterVerifierArgs {
     pub amount_lamports: u64,
-}
-
-impl RegisterVerifierArgs {
-    pub fn try_from_bytes(data: &[u8]) -> Result<Self, ProgramError> {
-        let view = <Self as Decodable>::decode(data)
-            .map_err(super::super::state::layout_error_to_program_error)?;
-
-        Ok(Self {
-            amount_lamports: view.amount_lamports(),
-        })
-    }
 }

--- a/dlp-api/src/v2/args/register_verifier.rs
+++ b/dlp-api/src/v2/args/register_verifier.rs
@@ -1,7 +1,7 @@
 use wheels::variable_offset_layout;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[variable_offset_layout(buffer_offset = 0)]
+#[variable_offset_layout(buffer_offset = 1)]
 pub struct RegisterVerifierArgs {
     pub amount_lamports: u64,
 }

--- a/dlp-api/src/v2/args/register_verifier.rs
+++ b/dlp-api/src/v2/args/register_verifier.rs
@@ -1,0 +1,20 @@
+use wheels::{layout::Decodable, variable_offset_layout};
+
+use crate::solana_program::program_error::ProgramError;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[variable_offset_layout(buffer_offset = unaligned)]
+pub struct RegisterVerifierArgs {
+    pub amount_lamports: u64,
+}
+
+impl RegisterVerifierArgs {
+    pub fn try_from_bytes(data: &[u8]) -> Result<Self, ProgramError> {
+        let view = <Self as Decodable>::decode(data)
+            .map_err(super::super::state::layout_error_to_program_error)?;
+
+        Ok(Self {
+            amount_lamports: view.amount_lamports(),
+        })
+    }
+}

--- a/dlp-api/src/v2/args/register_verifier.rs
+++ b/dlp-api/src/v2/args/register_verifier.rs
@@ -3,5 +3,5 @@ use wheels::variable_offset_layout;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[variable_offset_layout(buffer_offset = 1)]
 pub struct RegisterVerifierArgs {
-    pub amount_lamports: u64,
+    pub stake_lamports: u64,
 }

--- a/dlp-api/src/v2/instruction.rs
+++ b/dlp-api/src/v2/instruction.rs
@@ -9,6 +9,8 @@ pub enum DlpV2Instruction {
     InitProtocolConfig = 100,
     /// Registers one operator and deposits its initial stake.
     RegisterOperator = 101,
+    /// Registers one verifier and deposits its initial stake.
+    RegisterVerifier = 102,
 }
 
 impl DlpV2Instruction {

--- a/dlp-api/src/v2/instruction_builder/mod.rs
+++ b/dlp-api/src/v2/instruction_builder/mod.rs
@@ -1,5 +1,7 @@
 mod init_protocol_config;
 mod register_operator;
+mod register_verifier;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
+pub use register_verifier::*;

--- a/dlp-api/src/v2/instruction_builder/register_verifier.rs
+++ b/dlp-api/src/v2/instruction_builder/register_verifier.rs
@@ -1,0 +1,40 @@
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+use solana_sdk_ids::system_program;
+use wheels::layout::Encodable;
+
+use crate::{
+    compat::{Compatize, Modernize},
+    v2::{
+        pda::{protocol_config_pda, verifier_bond_pda},
+        DlpV2Instruction, RegisterVerifierArgs,
+    },
+};
+
+/// Builds the instruction that registers one verifier for v2 approvals.
+pub fn register_verifier(
+    verifier: Pubkey,
+    authority: Pubkey,
+    args: RegisterVerifierArgs,
+) -> Instruction {
+    Instruction {
+        program_id: crate::id().modernize(),
+        accounts: vec![
+            AccountMeta::new(verifier, true),
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(
+                verifier_bond_pda(&verifier.compatize()).modernize(),
+                false,
+            ),
+            AccountMeta::new_readonly(protocol_config_pda().modernize(), false),
+            AccountMeta::new_readonly(system_program::id(), false),
+        ],
+        data: [
+            DlpV2Instruction::RegisterVerifier.to_vec(),
+            args.encode().unwrap(),
+        ]
+        .concat(),
+    }
+}

--- a/dlp-api/src/v2/pda.rs
+++ b/dlp-api/src/v2/pda.rs
@@ -2,6 +2,7 @@ use crate::compat::Pubkey;
 
 pub const PROTOCOL_CONFIG_SEED: &[u8] = b"protocol-config";
 pub const OPERATOR_BOND_SEED: &[u8] = b"operator-bond";
+pub const VERIFIER_BOND_SEED: &[u8] = b"verifier-bond";
 pub const VERIFIER_REGISTRY_SEED: &[u8] = b"verifier-registry";
 
 // TODO (snawaz): Precompute these addresses if PDA derivation becomes const-safe.
@@ -17,6 +18,14 @@ pub fn verifier_registry_pda() -> Pubkey {
 pub fn operator_bond_pda(operator: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[OPERATOR_BOND_SEED, operator.as_ref()],
+        &crate::id(),
+    )
+    .0
+}
+
+pub fn verifier_bond_pda(verifier: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[VERIFIER_BOND_SEED, verifier.as_ref()],
         &crate::id(),
     )
     .0

--- a/dlp-api/src/v2/state/mod.rs
+++ b/dlp-api/src/v2/state/mod.rs
@@ -1,7 +1,11 @@
 mod operator_bond;
 mod protocol_config;
+mod utils;
+mod verifier_bond;
 mod verifier_registry;
 
 pub use operator_bond::*;
 pub use protocol_config::*;
+pub use utils::layout_error_to_program_error;
+pub use verifier_bond::*;
 pub use verifier_registry::*;

--- a/dlp-api/src/v2/state/mod.rs
+++ b/dlp-api/src/v2/state/mod.rs
@@ -1,11 +1,9 @@
 mod operator_bond;
 mod protocol_config;
-mod utils;
 mod verifier_bond;
 mod verifier_registry;
 
 pub use operator_bond::*;
 pub use protocol_config::*;
-pub use utils::layout_error_to_program_error;
 pub use verifier_bond::*;
 pub use verifier_registry::*;

--- a/dlp-api/src/v2/state/verifier_bond.rs
+++ b/dlp-api/src/v2/state/verifier_bond.rs
@@ -2,27 +2,31 @@ use wheels::fixed_offset_layout;
 
 use crate::compat::Pubkey;
 
-pub const VERIFIER_STATUS_ACTIVE: u8 = 1;
-pub const VERIFIER_STATUS_EXITING: u8 = 2;
-pub const VERIFIER_STATUS_SLASHED: u8 = 3;
-pub const VERIFIER_STATUS_JAILED: u8 = 4;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[fixed_offset_layout(buffer_offset = 0)]
 pub struct VerifierBond {
     /// Account type marker.
     pub discriminator: [u8; 8],
 
+    /// Canonical PDA bump for this account.
+    pub bump: u8,
+
     /// Verifier identity allowed to approve commitments through this bond.
     pub verifier_identity: Pubkey,
 
     /// Slashable verifier stake held in this account.
+    /// CHECKPOINT: the staking asset is SOL or BLOCK?
+    /// If this changes to BLOCK, this field will need to point at token-account
+    /// accounting instead of native lamports.
     pub stake_lamports: u64,
 
-    /// Current verifier lifecycle state.
+    /// Current verifier lifecycle state, stored as `VerifierStatus::value()`.
     pub status: u8,
 
     /// Slot when the verifier registered.
+    /// CHECKPOINT: keep this only if future verifier eligibility rules compare
+    /// the current slot with this registration slot, such as requiring a newly
+    /// registered verifier to wait before it can be selected or approve.
     pub registered_slot: u64,
 
     /// Slot when withdrawal was requested, if the verifier is exiting.
@@ -31,4 +35,19 @@ pub struct VerifierBond {
 
 impl VerifierBond {
     pub const DISCRIMINATOR: [u8; 8] = *b"v2vrbond";
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifierStatus {
+    Active = 1,
+    Exiting = 2,
+    Slashed = 3,
+    Jailed = 4,
+}
+
+impl VerifierStatus {
+    pub const fn value(self) -> u8 {
+        self as u8
+    }
 }

--- a/dlp-api/src/v2/state/verifier_bond.rs
+++ b/dlp-api/src/v2/state/verifier_bond.rs
@@ -1,0 +1,58 @@
+use wheels::{
+    fixed_offset_layout,
+    layout::{Decodable, Encodable},
+};
+
+use crate::{compat::Pubkey, solana_program::program_error::ProgramError};
+
+pub const VERIFIER_STATUS_ACTIVE: u8 = 1;
+pub const VERIFIER_STATUS_EXITING: u8 = 2;
+pub const VERIFIER_STATUS_SLASHED: u8 = 3;
+pub const VERIFIER_STATUS_JAILED: u8 = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[fixed_offset_layout(buffer_offset = 0)]
+pub struct VerifierBond {
+    pub verifier_identity: Pubkey,
+    pub stake_lamports: u64,
+    pub status: u8,
+    pub registered_slot: u64,
+    pub withdraw_requested_slot: Option<u64>,
+}
+
+impl VerifierBond {
+    pub const DISCRIMINATOR: [u8; 8] = *b"v2vrbond";
+    pub const SPACE: usize = 8 + Self::DATA_LEN;
+
+    pub fn to_bytes_with_discriminator(
+        &self,
+        data: &mut [u8],
+    ) -> Result<(), ProgramError> {
+        let payload = super::utils::payload_with_discriminator_mut(
+            &Self::DISCRIMINATOR,
+            data,
+        )?;
+        self.encode_to(payload)
+            .map_err(super::utils::layout_error_to_program_error)?;
+        Ok(())
+    }
+
+    pub fn try_from_bytes_with_discriminator(
+        data: &[u8],
+    ) -> Result<Self, ProgramError> {
+        let payload = super::utils::payload_with_discriminator(
+            &Self::DISCRIMINATOR,
+            data,
+        )?;
+        let view = <Self as Decodable>::decode(payload)
+            .map_err(super::utils::layout_error_to_program_error)?;
+
+        Ok(Self {
+            verifier_identity: *view.verifier_identity(),
+            stake_lamports: view.stake_lamports(),
+            status: view.status(),
+            registered_slot: view.registered_slot(),
+            withdraw_requested_slot: view.withdraw_requested_slot(),
+        })
+    }
+}

--- a/dlp-api/src/v2/state/verifier_bond.rs
+++ b/dlp-api/src/v2/state/verifier_bond.rs
@@ -1,9 +1,6 @@
-use wheels::{
-    fixed_offset_layout,
-    layout::{Decodable, Encodable},
-};
+use wheels::fixed_offset_layout;
 
-use crate::{compat::Pubkey, solana_program::program_error::ProgramError};
+use crate::compat::Pubkey;
 
 pub const VERIFIER_STATUS_ACTIVE: u8 = 1;
 pub const VERIFIER_STATUS_EXITING: u8 = 2;
@@ -13,46 +10,25 @@ pub const VERIFIER_STATUS_JAILED: u8 = 4;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[fixed_offset_layout(buffer_offset = 0)]
 pub struct VerifierBond {
+    /// Account type marker.
+    pub discriminator: [u8; 8],
+
+    /// Verifier identity allowed to approve commitments through this bond.
     pub verifier_identity: Pubkey,
+
+    /// Slashable verifier stake held in this account.
     pub stake_lamports: u64,
+
+    /// Current verifier lifecycle state.
     pub status: u8,
+
+    /// Slot when the verifier registered.
     pub registered_slot: u64,
+
+    /// Slot when withdrawal was requested, if the verifier is exiting.
     pub withdraw_requested_slot: Option<u64>,
 }
 
 impl VerifierBond {
     pub const DISCRIMINATOR: [u8; 8] = *b"v2vrbond";
-    pub const SPACE: usize = 8 + Self::DATA_LEN;
-
-    pub fn to_bytes_with_discriminator(
-        &self,
-        data: &mut [u8],
-    ) -> Result<(), ProgramError> {
-        let payload = super::utils::payload_with_discriminator_mut(
-            &Self::DISCRIMINATOR,
-            data,
-        )?;
-        self.encode_to(payload)
-            .map_err(super::utils::layout_error_to_program_error)?;
-        Ok(())
-    }
-
-    pub fn try_from_bytes_with_discriminator(
-        data: &[u8],
-    ) -> Result<Self, ProgramError> {
-        let payload = super::utils::payload_with_discriminator(
-            &Self::DISCRIMINATOR,
-            data,
-        )?;
-        let view = <Self as Decodable>::decode(payload)
-            .map_err(super::utils::layout_error_to_program_error)?;
-
-        Ok(Self {
-            verifier_identity: *view.verifier_identity(),
-            stake_lamports: view.stake_lamports(),
-            status: view.status(),
-            registered_slot: view.registered_slot(),
-            withdraw_requested_slot: view.withdraw_requested_slot(),
-        })
-    }
 }

--- a/src/v2/processor/bootstrap/mod.rs
+++ b/src/v2/processor/bootstrap/mod.rs
@@ -1,5 +1,7 @@
 mod init_protocol_config;
 mod register_operator;
+mod register_verifier;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
+pub use register_verifier::*;

--- a/src/v2/processor/bootstrap/register_verifier.rs
+++ b/src/v2/processor/bootstrap/register_verifier.rs
@@ -1,0 +1,120 @@
+use dlp_api::{
+    error::DlpError,
+    v2::{
+        pda::{PROTOCOL_CONFIG_SEED, VERIFIER_BOND_SEED},
+        ProtocolConfig, RegisterVerifierArgs, VerifierBond,
+        VERIFIER_STATUS_ACTIVE,
+    },
+};
+use solana_sdk_ids::system_program;
+use solana_system_interface::instruction as system_instruction;
+
+use crate::{
+    processor::utils::{
+        loaders::{
+            load_initialized_pda, load_program, load_signer,
+            load_uninitialized_pda,
+        },
+        pda::create_pda,
+    },
+    solana_program::{
+        account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
+        program::invoke, program_error::ProgramError, pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+};
+
+/// Register one verifier for v2 approvals.
+///
+/// Accounts:
+/// 0: `[signer, writable]` verifier identity and stake payer
+/// 1: `[signer]`           protocol authority that admits the verifier
+/// 2: `[writable]`         VerifierBond PDA
+/// 3: `[]`                 ProtocolConfig PDA
+/// 4: `[]`                 system program
+pub fn process_register_verifier(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: &[u8],
+) -> ProgramResult {
+    let args = RegisterVerifierArgs::try_from_bytes(data)?;
+
+    let [verifier, authority, verifier_bond, protocol_config, system_program] =
+        accounts
+    else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    load_signer(verifier, "verifier")?;
+    load_signer(authority, "authority")?;
+    load_program(system_program, system_program::id(), "system program")?;
+
+    load_initialized_pda(
+        protocol_config,
+        &[PROTOCOL_CONFIG_SEED],
+        &crate::id(),
+        false,
+        "protocol config",
+    )?;
+
+    let protocol_config_data = protocol_config.try_borrow_data()?;
+    let protocol_config_state =
+        ProtocolConfig::try_from_bytes_with_discriminator(
+            protocol_config_data.as_ref(),
+        )?;
+
+    if protocol_config_state.authority != *authority.key {
+        return Err(DlpError::InvalidAuthority.into());
+    }
+
+    if *verifier.key == Pubkey::default()
+        || args.amount_lamports < protocol_config_state.min_verifier_bond
+    {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let verifier_bond_bump = load_uninitialized_pda(
+        verifier_bond,
+        &[VERIFIER_BOND_SEED, verifier.key.as_ref()],
+        &crate::id(),
+        true,
+        "verifier bond",
+    )?;
+
+    create_pda(
+        verifier_bond,
+        &crate::id(),
+        VerifierBond::SPACE,
+        &[VERIFIER_BOND_SEED, verifier.key.as_ref()],
+        verifier_bond_bump,
+        system_program,
+        verifier,
+    )?;
+
+    invoke(
+        &system_instruction::transfer(
+            verifier.key,
+            verifier_bond.key,
+            args.amount_lamports,
+        ),
+        &[
+            verifier.clone(),
+            verifier_bond.clone(),
+            system_program.clone(),
+        ],
+    )?;
+
+    let verifier_bond_state = VerifierBond {
+        verifier_identity: *verifier.key,
+        stake_lamports: args.amount_lamports,
+        status: VERIFIER_STATUS_ACTIVE,
+        registered_slot: Clock::get()?.slot,
+        withdraw_requested_slot: None,
+    };
+
+    let mut verifier_bond_data = verifier_bond.try_borrow_mut_data()?;
+    verifier_bond_state
+        .to_bytes_with_discriminator(verifier_bond_data.as_mut())?;
+
+    Ok(())
+}

--- a/src/v2/processor/bootstrap/register_verifier.rs
+++ b/src/v2/processor/bootstrap/register_verifier.rs
@@ -2,12 +2,10 @@ use dlp_api::{
     error::DlpError,
     v2::{
         pda::{PROTOCOL_CONFIG_SEED, VERIFIER_BOND_SEED},
-        ProtocolConfig, RegisterVerifierArgs, VerifierBond,
-        VERIFIER_STATUS_ACTIVE,
+        ProtocolConfig, RegisterVerifierArgs, VerifierBond, VerifierStatus,
     },
 };
 use pinocchio::{
-    address::Address,
     cpi::{Seed, Signer},
     error::ProgramError,
     sysvars::{clock::Clock, Sysvar},
@@ -16,8 +14,7 @@ use pinocchio::{
 use pinocchio_system::instructions as system;
 use wheels::{
     layout::{Decodable, Encodable},
-    require_eq_keys, require_ge, require_n_accounts, require_ne,
-    require_signer,
+    require, require_eq_keys, require_ge, require_n_accounts, require_signer,
 };
 
 use crate::{
@@ -48,10 +45,10 @@ pub fn process_register_verifier(
         _system_program,
     ] = require_n_accounts!(accounts, 5);
 
-    let args = RegisterVerifierArgs::decode(data)?;
-
     require_signer!(verifier);
     require_signer!(authority);
+
+    let args = RegisterVerifierArgs::decode(data)?;
 
     require_initialized_pda(
         protocol_config,
@@ -63,24 +60,22 @@ pub fn process_register_verifier(
     let protocol_config_data = protocol_config.try_borrow()?;
     let protocol_config_state =
         ProtocolConfig::decode(protocol_config_data.as_ref())?;
-    if protocol_config_state.discriminator() != ProtocolConfig::DISCRIMINATOR {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    require!(
+        protocol_config_state.discriminator() == ProtocolConfig::DISCRIMINATOR,
+        ProgramError::InvalidAccountData
+    );
+
     require_eq_keys!(
-        &Address::from(protocol_config_state.authority().to_bytes()),
+        protocol_config_state.authority(),
         authority.address(),
         DlpError::InvalidAuthority
     );
-    require_ne!(
-        args.amount_lamports(),
-        0,
-        ProgramError::InvalidInstructionData
-    );
     require_ge!(
-        args.amount_lamports(),
+        args.stake_lamports(),
         protocol_config_state.min_verifier_bond(),
         ProgramError::InvalidInstructionData
     );
+
     drop(protocol_config_data);
 
     let verifier_bond_bump = require_uninitialized_pda(
@@ -106,15 +101,16 @@ pub fn process_register_verifier(
     system::Transfer {
         from: verifier,
         to: verifier_bond,
-        lamports: args.amount_lamports(),
+        lamports: args.stake_lamports(),
     }
     .invoke()?;
 
     VerifierBond {
         discriminator: VerifierBond::DISCRIMINATOR,
+        bump: verifier_bond_bump,
         verifier_identity: verifier.address().to_bytes().into(),
-        stake_lamports: args.amount_lamports(),
-        status: VERIFIER_STATUS_ACTIVE,
+        stake_lamports: args.stake_lamports(),
+        status: VerifierStatus::Active.value(),
         registered_slot: Clock::get()?.slot,
         withdraw_requested_slot: None,
     }

--- a/src/v2/processor/bootstrap/register_verifier.rs
+++ b/src/v2/processor/bootstrap/register_verifier.rs
@@ -6,21 +6,24 @@ use dlp_api::{
         VERIFIER_STATUS_ACTIVE,
     },
 };
-use solana_sdk_ids::system_program;
-use solana_system_interface::instruction as system_instruction;
+use pinocchio::{
+    address::Address,
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    AccountView, ProgramResult,
+};
+use pinocchio_system::instructions as system;
+use wheels::{
+    layout::{Decodable, Encodable},
+    require_eq_keys, require_ge, require_n_accounts, require_ne,
+    require_signer,
+};
 
 use crate::{
-    processor::utils::{
-        loaders::{
-            load_initialized_pda, load_program, load_signer,
-            load_uninitialized_pda,
-        },
-        pda::create_pda,
-    },
-    solana_program::{
-        account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
-        program::invoke, program_error::ProgramError, pubkey::Pubkey,
-        sysvar::Sysvar,
+    processor::fast::utils::pda::create_pda,
+    requires::{
+        require_initialized_pda, require_uninitialized_pda, StandardCtx,
     },
 };
 
@@ -31,90 +34,91 @@ use crate::{
 /// 1: `[signer]`           protocol authority that admits the verifier
 /// 2: `[writable]`         VerifierBond PDA
 /// 3: `[]`                 ProtocolConfig PDA
-/// 4: `[]`                 system program
+/// 4: `[]`                 system program, required by system CPI
+#[inline(never)]
 pub fn process_register_verifier(
-    _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountView],
     data: &[u8],
 ) -> ProgramResult {
-    let args = RegisterVerifierArgs::try_from_bytes(data)?;
+    let [
+        verifier, // force multi-line
+        authority,
+        verifier_bond,
+        protocol_config,
+        _system_program,
+    ] = require_n_accounts!(accounts, 5);
 
-    let [verifier, authority, verifier_bond, protocol_config, system_program] =
-        accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
+    let args = RegisterVerifierArgs::decode(data)?;
 
-    load_signer(verifier, "verifier")?;
-    load_signer(authority, "authority")?;
-    load_program(system_program, system_program::id(), "system program")?;
+    require_signer!(verifier);
+    require_signer!(authority);
 
-    load_initialized_pda(
+    require_initialized_pda(
         protocol_config,
         &[PROTOCOL_CONFIG_SEED],
-        &crate::id(),
+        &crate::fast::ID,
         false,
         "protocol config",
     )?;
-
-    let protocol_config_data = protocol_config.try_borrow_data()?;
+    let protocol_config_data = protocol_config.try_borrow()?;
     let protocol_config_state =
-        ProtocolConfig::try_from_bytes_with_discriminator(
-            protocol_config_data.as_ref(),
-        )?;
-
-    if protocol_config_state.authority != *authority.key {
-        return Err(DlpError::InvalidAuthority.into());
+        ProtocolConfig::decode(protocol_config_data.as_ref())?;
+    if protocol_config_state.discriminator() != ProtocolConfig::DISCRIMINATOR {
+        return Err(ProgramError::InvalidAccountData);
     }
+    require_eq_keys!(
+        &Address::from(protocol_config_state.authority().to_bytes()),
+        authority.address(),
+        DlpError::InvalidAuthority
+    );
+    require_ne!(
+        args.amount_lamports(),
+        0,
+        ProgramError::InvalidInstructionData
+    );
+    require_ge!(
+        args.amount_lamports(),
+        protocol_config_state.min_verifier_bond(),
+        ProgramError::InvalidInstructionData
+    );
+    drop(protocol_config_data);
 
-    if *verifier.key == Pubkey::default()
-        || args.amount_lamports < protocol_config_state.min_verifier_bond
-    {
-        return Err(ProgramError::InvalidInstructionData);
-    }
-
-    let verifier_bond_bump = load_uninitialized_pda(
+    let verifier_bond_bump = require_uninitialized_pda(
         verifier_bond,
-        &[VERIFIER_BOND_SEED, verifier.key.as_ref()],
-        &crate::id(),
+        &[VERIFIER_BOND_SEED, verifier.address().as_ref()],
+        &crate::fast::ID,
         true,
-        "verifier bond",
+        StandardCtx::new("verifier bond"),
     )?;
 
     create_pda(
         verifier_bond,
-        &crate::id(),
-        VerifierBond::SPACE,
-        &[VERIFIER_BOND_SEED, verifier.key.as_ref()],
-        verifier_bond_bump,
-        system_program,
+        &crate::fast::ID,
+        VerifierBond::DATA_LEN,
+        &[Signer::from(&[
+            Seed::from(VERIFIER_BOND_SEED),
+            Seed::from(verifier.address().as_ref()),
+            Seed::from(&[verifier_bond_bump]),
+        ])],
         verifier,
     )?;
 
-    invoke(
-        &system_instruction::transfer(
-            verifier.key,
-            verifier_bond.key,
-            args.amount_lamports,
-        ),
-        &[
-            verifier.clone(),
-            verifier_bond.clone(),
-            system_program.clone(),
-        ],
-    )?;
+    system::Transfer {
+        from: verifier,
+        to: verifier_bond,
+        lamports: args.amount_lamports(),
+    }
+    .invoke()?;
 
-    let verifier_bond_state = VerifierBond {
-        verifier_identity: *verifier.key,
-        stake_lamports: args.amount_lamports,
+    VerifierBond {
+        discriminator: VerifierBond::DISCRIMINATOR,
+        verifier_identity: verifier.address().to_bytes().into(),
+        stake_lamports: args.amount_lamports(),
         status: VERIFIER_STATUS_ACTIVE,
         registered_slot: Clock::get()?.slot,
         withdraw_requested_slot: None,
-    };
-
-    let mut verifier_bond_data = verifier_bond.try_borrow_mut_data()?;
-    verifier_bond_state
-        .to_bytes_with_discriminator(verifier_bond_data.as_mut())?;
+    }
+    .encode_to(verifier_bond.try_borrow_mut()?.as_mut())?;
 
     Ok(())
 }

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -20,7 +20,7 @@ pub fn process_instruction(
             process_register_operator(accounts, data)
         }
         DlpV2Instruction::RegisterVerifier => {
-            process_register_verifier(program_id, accounts, data)
+            process_register_verifier(accounts, data)
         }
     }
 }

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -19,5 +19,8 @@ pub fn process_instruction(
         DlpV2Instruction::RegisterOperator => {
             process_register_operator(accounts, data)
         }
+        DlpV2Instruction::RegisterVerifier => {
+            process_register_verifier(program_id, accounts, data)
+        }
     }
 }

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -13,15 +13,25 @@ use wheels::layout::Decodable;
 
 mod fixtures;
 
-use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+use crate::fixtures::v2::{
+    initialize_protocol_config, setup_program_test_env,
+    valid_protocol_config_args,
+};
 
 #[tokio::test]
-async fn test_v2_register_verifier() {
+async fn test_register_verifier() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let verifier = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_verifier(&banks, &payer, &verifier).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
@@ -66,12 +76,19 @@ async fn test_v2_register_verifier() {
 }
 
 #[tokio::test]
-async fn test_v2_register_verifier_fails_with_wrong_authority() {
+async fn test_register_verifier_fails_with_wrong_authority() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let verifier = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_verifier(&banks, &payer, &verifier).await;
 
     let wrong_authority = Keypair::new();
@@ -94,12 +111,19 @@ async fn test_v2_register_verifier_fails_with_wrong_authority() {
 }
 
 #[tokio::test]
-async fn test_v2_register_verifier_fails_with_low_stake() {
+async fn test_register_verifier_fails_with_low_stake() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let verifier = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args,
+    )
+    .await;
     fund_verifier(&banks, &payer, &verifier).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
@@ -119,13 +143,20 @@ async fn test_v2_register_verifier_fails_with_low_stake() {
 }
 
 #[tokio::test]
-async fn test_v2_register_verifier_fails_twice() {
+async fn test_register_verifier_fails_twice() {
     let (mut banks, payer, authority, blockhash) =
         setup_program_test_env().await;
-    let config_args = valid_args();
+    let config_args = valid_protocol_config_args();
     let verifier = Keypair::new();
 
-    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        config_args.clone(),
+    )
+    .await;
     fund_verifier(&banks, &payer, &verifier).await;
 
     let ix = register_verifier(

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -1,19 +1,42 @@
 use dlp_api::v2::{
     instruction_builder::register_verifier, pda::verifier_bond_pda,
-    RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
+    DlpV2Instruction, RegisterVerifierArgs, VerifierBond,
+    VERIFIER_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
+    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 use solana_system_interface::instruction as system_instruction;
-use wheels::layout::Decodable;
+use wheels::layout::{Decodable, Encodable};
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[test]
+fn test_v2_register_verifier_instruction_data_uses_one_byte_tag() {
+    let args = RegisterVerifierArgs {
+        amount_lamports: 42,
+    };
+    let ix = register_verifier(
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        args.clone(),
+    );
+    let encoded_args = args.encode().unwrap();
+
+    assert_eq!(ix.data[0], DlpV2Instruction::RegisterVerifier as u8);
+    assert_eq!(ix.data.len(), 1 + encoded_args.len());
+    assert_eq!(&ix.data[1..], encoded_args.as_slice());
+
+    let decoded =
+        <RegisterVerifierArgs as Decodable>::decode(&ix.data[1..]).unwrap();
+    assert_eq!(decoded.amount_lamports(), args.amount_lamports);
+}
 
 #[tokio::test]
 async fn test_v2_register_verifier() {

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -1,42 +1,19 @@
 use dlp_api::v2::{
     instruction_builder::register_verifier, pda::verifier_bond_pda,
-    DlpV2Instruction, RegisterVerifierArgs, VerifierBond,
-    VERIFIER_STATUS_ACTIVE,
+    RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 use solana_system_interface::instruction as system_instruction;
-use wheels::layout::{Decodable, Encodable};
+use wheels::layout::Decodable;
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
-
-#[test]
-fn test_v2_register_verifier_instruction_data_uses_one_byte_tag() {
-    let args = RegisterVerifierArgs {
-        amount_lamports: 42,
-    };
-    let ix = register_verifier(
-        Pubkey::new_unique(),
-        Pubkey::new_unique(),
-        args.clone(),
-    );
-    let encoded_args = args.encode().unwrap();
-
-    assert_eq!(ix.data[0], DlpV2Instruction::RegisterVerifier as u8);
-    assert_eq!(ix.data.len(), 1 + encoded_args.len());
-    assert_eq!(&ix.data[1..], encoded_args.as_slice());
-
-    let decoded =
-        <RegisterVerifierArgs as Decodable>::decode(&ix.data[1..]).unwrap();
-    assert_eq!(decoded.amount_lamports(), args.amount_lamports);
-}
 
 #[tokio::test]
 async fn test_v2_register_verifier() {

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -1,0 +1,147 @@
+use dlp_api::v2::{
+    instruction_builder::register_verifier, pda::verifier_bond_pda,
+    RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
+};
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod fixtures;
+
+use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[tokio::test]
+async fn test_v2_register_verifier() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_verifier(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterVerifierArgs {
+            amount_lamports: config_args.min_verifier_bond,
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_ok());
+
+    let verifier_bond_account = banks
+        .get_account(verifier_bond_pda(&payer.pubkey()))
+        .await
+        .unwrap()
+        .unwrap();
+    let verifier_bond = VerifierBond::try_from_bytes_with_discriminator(
+        &verifier_bond_account.data,
+    )
+    .unwrap();
+
+    assert_eq!(verifier_bond.verifier_identity, payer.pubkey());
+    assert_eq!(verifier_bond.stake_lamports, config_args.min_verifier_bond);
+    assert_eq!(verifier_bond.status, VERIFIER_STATUS_ACTIVE);
+    assert!(verifier_bond.registered_slot > 0);
+    assert_eq!(verifier_bond.withdraw_requested_slot, None);
+    assert!(
+        verifier_bond_account.lamports > verifier_bond.stake_lamports,
+        "verifier bond account should hold rent plus stake"
+    );
+}
+
+#[tokio::test]
+async fn test_v2_register_verifier_fails_with_wrong_authority() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let wrong_authority = Keypair::new();
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_verifier(
+        payer.pubkey(),
+        wrong_authority.pubkey(),
+        RegisterVerifierArgs {
+            amount_lamports: config_args.min_verifier_bond,
+        },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &wrong_authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_register_verifier_fails_with_low_stake() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = register_verifier(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterVerifierArgs { amount_lamports: 0 },
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_register_verifier_fails_twice() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let config_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+
+    let ix = register_verifier(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterVerifierArgs {
+            amount_lamports: config_args.min_verifier_bond,
+        },
+    );
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+    banks.process_transaction(tx).await.unwrap();
+
+    let ix = register_verifier(
+        payer.pubkey(),
+        authority.pubkey(),
+        RegisterVerifierArgs {
+            amount_lamports: config_args.min_verifier_bond,
+        },
+    );
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -2,10 +2,13 @@ use dlp_api::v2::{
     instruction_builder::register_verifier, pda::verifier_bond_pda,
     RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
 };
+use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+use solana_system_interface::instruction as system_instruction;
+use wheels::layout::Decodable;
 
 mod fixtures;
 
@@ -15,12 +18,14 @@ use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
 async fn test_v2_register_verifier() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let verifier = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_verifier(&banks, &payer, &verifier).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_verifier(
-        payer.pubkey(),
+        verifier.pubkey(),
         authority.pubkey(),
         RegisterVerifierArgs {
             amount_lamports: config_args.min_verifier_bond,
@@ -29,29 +34,32 @@ async fn test_v2_register_verifier() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &verifier, &authority],
         blockhash,
     );
 
     assert!(banks.process_transaction(tx).await.is_ok());
 
     let verifier_bond_account = banks
-        .get_account(verifier_bond_pda(&payer.pubkey()))
+        .get_account(verifier_bond_pda(&verifier.pubkey()))
         .await
         .unwrap()
         .unwrap();
-    let verifier_bond = VerifierBond::try_from_bytes_with_discriminator(
-        &verifier_bond_account.data,
-    )
-    .unwrap();
+    let verifier_bond =
+        <VerifierBond as Decodable>::decode(&verifier_bond_account.data)
+            .unwrap();
 
-    assert_eq!(verifier_bond.verifier_identity, payer.pubkey());
-    assert_eq!(verifier_bond.stake_lamports, config_args.min_verifier_bond);
-    assert_eq!(verifier_bond.status, VERIFIER_STATUS_ACTIVE);
-    assert!(verifier_bond.registered_slot > 0);
-    assert_eq!(verifier_bond.withdraw_requested_slot, None);
+    assert_eq!(verifier_bond.discriminator(), VerifierBond::DISCRIMINATOR);
+    assert_eq!(*verifier_bond.verifier_identity(), verifier.pubkey());
+    assert_eq!(
+        verifier_bond.stake_lamports(),
+        config_args.min_verifier_bond
+    );
+    assert_eq!(verifier_bond.status(), VERIFIER_STATUS_ACTIVE);
+    assert!(verifier_bond.registered_slot() > 0);
+    assert_eq!(verifier_bond.withdraw_requested_slot(), None);
     assert!(
-        verifier_bond_account.lamports > verifier_bond.stake_lamports,
+        verifier_bond_account.lamports > verifier_bond.stake_lamports(),
         "verifier bond account should hold rent plus stake"
     );
 }
@@ -60,13 +68,15 @@ async fn test_v2_register_verifier() {
 async fn test_v2_register_verifier_fails_with_wrong_authority() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let verifier = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_verifier(&banks, &payer, &verifier).await;
 
     let wrong_authority = Keypair::new();
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_verifier(
-        payer.pubkey(),
+        verifier.pubkey(),
         wrong_authority.pubkey(),
         RegisterVerifierArgs {
             amount_lamports: config_args.min_verifier_bond,
@@ -75,7 +85,7 @@ async fn test_v2_register_verifier_fails_with_wrong_authority() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &wrong_authority],
+        &[&payer, &verifier, &wrong_authority],
         blockhash,
     );
 
@@ -86,19 +96,21 @@ async fn test_v2_register_verifier_fails_with_wrong_authority() {
 async fn test_v2_register_verifier_fails_with_low_stake() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let verifier = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args).await;
+    fund_verifier(&banks, &payer, &verifier).await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = register_verifier(
-        payer.pubkey(),
+        verifier.pubkey(),
         authority.pubkey(),
         RegisterVerifierArgs { amount_lamports: 0 },
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &verifier, &authority],
         blockhash,
     );
 
@@ -109,11 +121,13 @@ async fn test_v2_register_verifier_fails_with_low_stake() {
 async fn test_v2_register_verifier_fails_twice() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_args();
+    let verifier = Keypair::new();
 
     init_v2(&banks, &payer, &authority, blockhash, config_args.clone()).await;
+    fund_verifier(&banks, &payer, &verifier).await;
 
     let ix = register_verifier(
-        payer.pubkey(),
+        verifier.pubkey(),
         authority.pubkey(),
         RegisterVerifierArgs {
             amount_lamports: config_args.min_verifier_bond,
@@ -123,13 +137,13 @@ async fn test_v2_register_verifier_fails_twice() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &verifier, &authority],
         blockhash,
     );
     banks.process_transaction(tx).await.unwrap();
 
     let ix = register_verifier(
-        payer.pubkey(),
+        verifier.pubkey(),
         authority.pubkey(),
         RegisterVerifierArgs {
             amount_lamports: config_args.min_verifier_bond,
@@ -139,9 +153,30 @@ async fn test_v2_register_verifier_fails_twice() {
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
-        &[&payer, &authority],
+        &[&payer, &verifier, &authority],
         blockhash,
     );
 
     assert!(banks.process_transaction(tx).await.is_err());
+}
+
+async fn fund_verifier(
+    banks: &solana_program_test::BanksClient,
+    payer: &Keypair,
+    verifier: &Keypair,
+) {
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = system_instruction::transfer(
+        &payer.pubkey(),
+        &verifier.pubkey(),
+        LAMPORTS_PER_SOL,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        blockhash,
+    );
+
+    banks.process_transaction(tx).await.unwrap();
 }

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -3,6 +3,7 @@ use dlp_api::v2::{
     RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
 };
 use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
@@ -119,7 +120,8 @@ async fn test_v2_register_verifier_fails_with_low_stake() {
 
 #[tokio::test]
 async fn test_v2_register_verifier_fails_twice() {
-    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let (mut banks, payer, authority, blockhash) =
+        setup_program_test_env().await;
     let config_args = valid_args();
     let verifier = Keypair::new();
 
@@ -133,7 +135,11 @@ async fn test_v2_register_verifier_fails_twice() {
             amount_lamports: config_args.min_verifier_bond,
         },
     );
-    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+    let blockhash = banks
+        .get_new_latest_blockhash(&latest_blockhash)
+        .await
+        .unwrap();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -149,7 +155,11 @@ async fn test_v2_register_verifier_fails_twice() {
             amount_lamports: config_args.min_verifier_bond,
         },
     );
-    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+    let blockhash = banks
+        .get_new_latest_blockhash(&latest_blockhash)
+        .await
+        .unwrap();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),

--- a/tests/test_v2_register_verifier.rs
+++ b/tests/test_v2_register_verifier.rs
@@ -1,8 +1,10 @@
 use dlp_api::v2::{
-    instruction_builder::register_verifier, pda::verifier_bond_pda,
-    RegisterVerifierArgs, VerifierBond, VERIFIER_STATUS_ACTIVE,
+    instruction_builder::register_verifier, pda::VERIFIER_BOND_SEED,
+    RegisterVerifierArgs, VerifierBond, VerifierStatus,
 };
-use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_program::{
+    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, rent::Rent,
+};
 use solana_program_test::ProgramTestBanksClientExt;
 use solana_sdk::{
     signature::{Keypair, Signer},
@@ -23,6 +25,11 @@ async fn test_register_verifier() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
     let config_args = valid_protocol_config_args();
     let verifier = Keypair::new();
+    let (verifier_bond_address, expected_verifier_bond_bump) =
+        Pubkey::find_program_address(
+            &[VERIFIER_BOND_SEED, verifier.pubkey().as_ref()],
+            &dlp_api::id(),
+        );
 
     initialize_protocol_config(
         &banks,
@@ -39,7 +46,7 @@ async fn test_register_verifier() {
         verifier.pubkey(),
         authority.pubkey(),
         RegisterVerifierArgs {
-            amount_lamports: config_args.min_verifier_bond,
+            stake_lamports: config_args.min_verifier_bond,
         },
     );
     let tx = Transaction::new_signed_with_payer(
@@ -52,26 +59,29 @@ async fn test_register_verifier() {
     assert!(banks.process_transaction(tx).await.is_ok());
 
     let verifier_bond_account = banks
-        .get_account(verifier_bond_pda(&verifier.pubkey()))
+        .get_account(verifier_bond_address)
         .await
         .unwrap()
         .unwrap();
     let verifier_bond =
-        <VerifierBond as Decodable>::decode(&verifier_bond_account.data)
-            .unwrap();
+        VerifierBond::decode(&verifier_bond_account.data).unwrap();
+    let expected_verifier_bond_lamports = Rent::default()
+        .minimum_balance(VerifierBond::DATA_LEN)
+        + config_args.min_verifier_bond;
 
     assert_eq!(verifier_bond.discriminator(), VerifierBond::DISCRIMINATOR);
+    assert_eq!(verifier_bond.bump(), expected_verifier_bond_bump);
     assert_eq!(*verifier_bond.verifier_identity(), verifier.pubkey());
     assert_eq!(
         verifier_bond.stake_lamports(),
         config_args.min_verifier_bond
     );
-    assert_eq!(verifier_bond.status(), VERIFIER_STATUS_ACTIVE);
+    assert_eq!(verifier_bond.status(), VerifierStatus::Active.value());
     assert!(verifier_bond.registered_slot() > 0);
     assert_eq!(verifier_bond.withdraw_requested_slot(), None);
-    assert!(
-        verifier_bond_account.lamports > verifier_bond.stake_lamports(),
-        "verifier bond account should hold rent plus stake"
+    assert_eq!(
+        verifier_bond_account.lamports,
+        expected_verifier_bond_lamports
     );
 }
 
@@ -97,7 +107,7 @@ async fn test_register_verifier_fails_with_wrong_authority() {
         verifier.pubkey(),
         wrong_authority.pubkey(),
         RegisterVerifierArgs {
-            amount_lamports: config_args.min_verifier_bond,
+            stake_lamports: config_args.min_verifier_bond,
         },
     );
     let tx = Transaction::new_signed_with_payer(
@@ -130,7 +140,7 @@ async fn test_register_verifier_fails_with_low_stake() {
     let ix = register_verifier(
         verifier.pubkey(),
         authority.pubkey(),
-        RegisterVerifierArgs { amount_lamports: 0 },
+        RegisterVerifierArgs { stake_lamports: 0 },
     );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
@@ -159,46 +169,50 @@ async fn test_register_verifier_fails_twice() {
     .await;
     fund_verifier(&banks, &payer, &verifier).await;
 
-    let ix = register_verifier(
-        verifier.pubkey(),
-        authority.pubkey(),
-        RegisterVerifierArgs {
-            amount_lamports: config_args.min_verifier_bond,
-        },
-    );
-    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
-    let blockhash = banks
-        .get_new_latest_blockhash(&latest_blockhash)
-        .await
-        .unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&payer.pubkey()),
-        &[&payer, &verifier, &authority],
-        blockhash,
-    );
-    banks.process_transaction(tx).await.unwrap();
+    {
+        let ix = register_verifier(
+            verifier.pubkey(),
+            authority.pubkey(),
+            RegisterVerifierArgs {
+                stake_lamports: config_args.min_verifier_bond,
+            },
+        );
+        let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+        let blockhash = banks
+            .get_new_latest_blockhash(&latest_blockhash)
+            .await
+            .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&payer.pubkey()),
+            &[&payer, &verifier, &authority],
+            blockhash,
+        );
+        banks.process_transaction(tx).await.unwrap();
+    }
 
-    let ix = register_verifier(
-        verifier.pubkey(),
-        authority.pubkey(),
-        RegisterVerifierArgs {
-            amount_lamports: config_args.min_verifier_bond,
-        },
-    );
-    let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
-    let blockhash = banks
-        .get_new_latest_blockhash(&latest_blockhash)
-        .await
-        .unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&payer.pubkey()),
-        &[&payer, &verifier, &authority],
-        blockhash,
-    );
+    {
+        let ix = register_verifier(
+            verifier.pubkey(),
+            authority.pubkey(),
+            RegisterVerifierArgs {
+                stake_lamports: config_args.min_verifier_bond,
+            },
+        );
+        let latest_blockhash = banks.get_latest_blockhash().await.unwrap();
+        let blockhash = banks
+            .get_new_latest_blockhash(&latest_blockhash)
+            .await
+            .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&payer.pubkey()),
+            &[&payer, &verifier, &authority],
+            blockhash,
+        );
 
-    assert!(banks.process_transaction(tx).await.is_err());
+        assert!(banks.process_transaction(tx).await.is_err());
+    }
 }
 
 async fn fund_verifier(


### PR DESCRIPTION
Implements the DLP v2 bootstrap instruction `RegisterVerifier`, which creates the verifier bond account and locks the verifier’s initial stake under the configured protocol authority.

Closes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verifier registration for DLP v2.
  * Verifiers can register by depositing the required minimum stake.
  * Added tracking for verifier identity, stake, registration slot, status, and withdrawal requests.
  * Added client support for creating verifier-registration instructions.
* **Bug Fixes**
  * Added validation to reject unauthorized registrations, invalid accounts, insufficient stakes, and duplicate registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->