### PR TITLE
feat(fraud-proofs): Implement UpdateProtocolConfig

### DIFF
--- a/dlp-api/src/v2/args/mod.rs
+++ b/dlp-api/src/v2/args/mod.rs
@@ -4,9 +4,11 @@
 mod init_protocol_config;
 mod register_operator;
 mod register_verifier;
+mod update_protocol_config;
 mod update_verifier_registry;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
 pub use register_verifier::*;
+pub use update_protocol_config::*;
 pub use update_verifier_registry::*;

--- a/dlp-api/src/v2/args/update_protocol_config.rs
+++ b/dlp-api/src/v2/args/update_protocol_config.rs
@@ -1,0 +1,1 @@
+pub type UpdateProtocolConfigArgs = super::InitProtocolConfigArgs;

--- a/dlp-api/src/v2/args/update_protocol_config.rs
+++ b/dlp-api/src/v2/args/update_protocol_config.rs
@@ -1,1 +1,5 @@
+// Update uses the same payload as init because every init-time config value in
+// this args type is also authority-updatable. Account identity fields such as
+// authority, fee vault, pause state, discriminator, and bump are preserved by
+// the processor instead of coming from instruction data.
 pub type UpdateProtocolConfigArgs = super::InitProtocolConfigArgs;

--- a/dlp-api/src/v2/instruction.rs
+++ b/dlp-api/src/v2/instruction.rs
@@ -13,6 +13,8 @@ pub enum DlpV2Instruction {
     RegisterVerifier = 102,
     /// Updates the set of verifiers that can be selected.
     UpdateVerifierRegistry = 103,
+    /// Updates global v2 config for future commitments.
+    UpdateProtocolConfig = 104,
 }
 
 impl DlpV2Instruction {

--- a/dlp-api/src/v2/instruction_builder/mod.rs
+++ b/dlp-api/src/v2/instruction_builder/mod.rs
@@ -1,9 +1,11 @@
 mod init_protocol_config;
 mod register_operator;
 mod register_verifier;
+mod update_protocol_config;
 mod update_verifier_registry;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
 pub use register_verifier::*;
+pub use update_protocol_config::*;
 pub use update_verifier_registry::*;

--- a/dlp-api/src/v2/instruction_builder/update_protocol_config.rs
+++ b/dlp-api/src/v2/instruction_builder/update_protocol_config.rs
@@ -1,0 +1,31 @@
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+use wheels::layout::Encodable;
+
+use crate::{
+    compat::Modernize,
+    v2::{
+        pda::protocol_config_pda, DlpV2Instruction, UpdateProtocolConfigArgs,
+    },
+};
+
+/// Builds the instruction that updates global v2 config for future work.
+pub fn update_protocol_config(
+    authority: Pubkey,
+    args: UpdateProtocolConfigArgs,
+) -> Instruction {
+    Instruction {
+        program_id: crate::id().modernize(),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(protocol_config_pda().modernize(), false),
+        ],
+        data: [
+            DlpV2Instruction::UpdateProtocolConfig.to_vec(),
+            args.encode().unwrap(),
+        ]
+        .concat(),
+    }
+}

--- a/src/v2/processor/bootstrap/mod.rs
+++ b/src/v2/processor/bootstrap/mod.rs
@@ -1,9 +1,11 @@
 mod init_protocol_config;
 mod register_operator;
 mod register_verifier;
+mod update_protocol_config;
 mod update_verifier_registry;
 
 pub use init_protocol_config::*;
 pub use register_operator::*;
 pub use register_verifier::*;
+pub use update_protocol_config::*;
 pub use update_verifier_registry::*;

--- a/src/v2/processor/bootstrap/update_protocol_config.rs
+++ b/src/v2/processor/bootstrap/update_protocol_config.rs
@@ -2,9 +2,7 @@ use dlp_api::{
     error::DlpError,
     v2::{pda::PROTOCOL_CONFIG_SEED, ProtocolConfig, UpdateProtocolConfigArgs},
 };
-use pinocchio::{
-    address::Address, error::ProgramError, AccountView, ProgramResult,
-};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use wheels::{
     layout::{Decodable, Encodable},
     require_eq_keys, require_n_accounts, require_signer,
@@ -45,7 +43,7 @@ pub fn process_update_protocol_config(
         return Err(ProgramError::InvalidAccountData);
     }
     require_eq_keys!(
-        &Address::from(current.authority().to_bytes()),
+        current.authority(),
         authority.address(),
         DlpError::InvalidAuthority
     );
@@ -54,6 +52,8 @@ pub fn process_update_protocol_config(
         discriminator: ProtocolConfig::DISCRIMINATOR,
         bump: current.bump(),
         authority: *current.authority(),
+        // CHECKPOINT: pause/unpause remains a separate design decision; this
+        // instruction deliberately preserves the current emergency-stop state.
         paused: current.paused(),
         resolver: *args.resolver(),
         protocol_fee_vault: *current.protocol_fee_vault(),

--- a/src/v2/processor/bootstrap/update_protocol_config.rs
+++ b/src/v2/processor/bootstrap/update_protocol_config.rs
@@ -52,6 +52,7 @@ pub fn process_update_protocol_config(
 
     let updated = ProtocolConfig {
         discriminator: ProtocolConfig::DISCRIMINATOR,
+        bump: current.bump(),
         authority: *current.authority(),
         paused: current.paused(),
         resolver: *args.resolver(),

--- a/src/v2/processor/bootstrap/update_protocol_config.rs
+++ b/src/v2/processor/bootstrap/update_protocol_config.rs
@@ -2,81 +2,75 @@ use dlp_api::{
     error::DlpError,
     v2::{pda::PROTOCOL_CONFIG_SEED, ProtocolConfig, UpdateProtocolConfigArgs},
 };
-
-use crate::{
-    processor::utils::loaders::{load_initialized_pda, load_signer},
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult,
-        program_error::ProgramError, pubkey::Pubkey,
-    },
+use pinocchio::{
+    address::Address, error::ProgramError, AccountView, ProgramResult,
 };
+use wheels::{
+    layout::{Decodable, Encodable},
+    require_eq_keys, require_n_accounts, require_signer,
+};
+
+use crate::requires::require_initialized_pda;
 
 /// Update global v2 config for future commitments.
 ///
 /// Accounts:
 /// 0: `[signer]`   protocol authority
 /// 1: `[writable]` ProtocolConfig PDA
+#[inline(never)]
 pub fn process_update_protocol_config(
-    _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountView],
     data: &[u8],
 ) -> ProgramResult {
-    let args = UpdateProtocolConfigArgs::try_from_bytes(data)?;
+    let [
+        authority, // force multi-line
+        protocol_config,
+    ] = require_n_accounts!(accounts, 2);
+
+    let args = UpdateProtocolConfigArgs::decode(data)?;
     super::validate_protocol_config_args(&args)?;
 
-    let [authority, protocol_config] = accounts else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-
-    load_signer(authority, "authority")?;
-    load_initialized_pda(
+    require_signer!(authority);
+    require_initialized_pda(
         protocol_config,
         &[PROTOCOL_CONFIG_SEED],
-        &crate::id(),
+        &crate::fast::ID,
         true,
         "protocol config",
     )?;
 
-    let protocol_config_data = protocol_config.try_borrow_data()?;
-    let current = ProtocolConfig::try_from_bytes_with_discriminator(
-        protocol_config_data.as_ref(),
-    )?;
+    let protocol_config_data = protocol_config.try_borrow()?;
+    let current = ProtocolConfig::decode(protocol_config_data.as_ref())?;
+    if current.discriminator() != ProtocolConfig::DISCRIMINATOR {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    require_eq_keys!(
+        &Address::from(current.authority().to_bytes()),
+        authority.address(),
+        DlpError::InvalidAuthority
+    );
+
+    let updated = ProtocolConfig {
+        discriminator: ProtocolConfig::DISCRIMINATOR,
+        authority: *current.authority(),
+        paused: current.paused(),
+        resolver: *args.resolver(),
+        protocol_fee_vault: *current.protocol_fee_vault(),
+        min_operator_bond: args.min_operator_bond(),
+        min_verifier_bond: args.min_verifier_bond(),
+        min_challenger_stake: args.min_challenger_stake(),
+        challenge_window_slots: args.challenge_window_slots(),
+        operator_response_timeout_slots: args.operator_response_timeout_slots(),
+        challenger_reveal_timeout_slots: args.challenger_reveal_timeout_slots(),
+        payout_timelock_slots: args.payout_timelock_slots(),
+        verifiers_per_commitment: args.verifiers_per_commitment(),
+        approval_threshold: args.approval_threshold(),
+        max_window_extensions: args.max_window_extensions(),
+        match_penalty_bps: args.match_penalty_bps(),
+    };
     drop(protocol_config_data);
 
-    if current.authority != *authority.key {
-        return Err(DlpError::InvalidAuthority.into());
-    }
-
-    // CHECKPOINT: authority rotation should be a separate instruction with
-    // explicit safety rules, not an accidental side effect of config updates.
-    //
-    // CHECKPOINT: pause/unpause may deserve separate instructions so emergency
-    // operations are easy to audit and hard to bundle with unrelated changes.
-    let updated = ProtocolConfig {
-        authority: current.authority,
-        paused: current.paused,
-        vrf_program: args.vrf_program,
-        vrf_config: args.vrf_config,
-        resolver: args.resolver,
-        protocol_fee_vault: current.protocol_fee_vault,
-        min_operator_bond: args.min_operator_bond,
-        min_verifier_bond: args.min_verifier_bond,
-        min_challenger_stake: args.min_challenger_stake,
-        challenge_window_slots: args.challenge_window_slots,
-        operator_response_timeout_slots: args.operator_response_timeout_slots,
-        challenger_reveal_timeout_slots: args.challenger_reveal_timeout_slots,
-        payout_timelock_slots: args.payout_timelock_slots,
-        selected_verifier_count: args.selected_verifier_count,
-        approval_threshold: args.approval_threshold,
-        max_window_extensions: args.max_window_extensions,
-        match_penalty_bps: args.match_penalty_bps,
-    };
-
-    // CHECKPOINT: when `PendingCommitment` is implemented, every config value
-    // that affects an active commitment must be copied into that commitment at
-    // creation time. Updates here should only affect future commitments.
-    let mut protocol_config_data = protocol_config.try_borrow_mut_data()?;
-    updated.to_bytes_with_discriminator(protocol_config_data.as_mut())?;
+    updated.encode_to(protocol_config.try_borrow_mut()?.as_mut())?;
 
     Ok(())
 }

--- a/src/v2/processor/bootstrap/update_protocol_config.rs
+++ b/src/v2/processor/bootstrap/update_protocol_config.rs
@@ -1,0 +1,82 @@
+use dlp_api::{
+    error::DlpError,
+    v2::{pda::PROTOCOL_CONFIG_SEED, ProtocolConfig, UpdateProtocolConfigArgs},
+};
+
+use crate::{
+    processor::utils::loaders::{load_initialized_pda, load_signer},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult,
+        program_error::ProgramError, pubkey::Pubkey,
+    },
+};
+
+/// Update global v2 config for future commitments.
+///
+/// Accounts:
+/// 0: `[signer]`   protocol authority
+/// 1: `[writable]` ProtocolConfig PDA
+pub fn process_update_protocol_config(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: &[u8],
+) -> ProgramResult {
+    let args = UpdateProtocolConfigArgs::try_from_bytes(data)?;
+    super::validate_protocol_config_args(&args)?;
+
+    let [authority, protocol_config] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    load_signer(authority, "authority")?;
+    load_initialized_pda(
+        protocol_config,
+        &[PROTOCOL_CONFIG_SEED],
+        &crate::id(),
+        true,
+        "protocol config",
+    )?;
+
+    let protocol_config_data = protocol_config.try_borrow_data()?;
+    let current = ProtocolConfig::try_from_bytes_with_discriminator(
+        protocol_config_data.as_ref(),
+    )?;
+    drop(protocol_config_data);
+
+    if current.authority != *authority.key {
+        return Err(DlpError::InvalidAuthority.into());
+    }
+
+    // CHECKPOINT: authority rotation should be a separate instruction with
+    // explicit safety rules, not an accidental side effect of config updates.
+    //
+    // CHECKPOINT: pause/unpause may deserve separate instructions so emergency
+    // operations are easy to audit and hard to bundle with unrelated changes.
+    let updated = ProtocolConfig {
+        authority: current.authority,
+        paused: current.paused,
+        vrf_program: args.vrf_program,
+        vrf_config: args.vrf_config,
+        resolver: args.resolver,
+        protocol_fee_vault: current.protocol_fee_vault,
+        min_operator_bond: args.min_operator_bond,
+        min_verifier_bond: args.min_verifier_bond,
+        min_challenger_stake: args.min_challenger_stake,
+        challenge_window_slots: args.challenge_window_slots,
+        operator_response_timeout_slots: args.operator_response_timeout_slots,
+        challenger_reveal_timeout_slots: args.challenger_reveal_timeout_slots,
+        payout_timelock_slots: args.payout_timelock_slots,
+        selected_verifier_count: args.selected_verifier_count,
+        approval_threshold: args.approval_threshold,
+        max_window_extensions: args.max_window_extensions,
+        match_penalty_bps: args.match_penalty_bps,
+    };
+
+    // CHECKPOINT: when `PendingCommitment` is implemented, every config value
+    // that affects an active commitment must be copied into that commitment at
+    // creation time. Updates here should only affect future commitments.
+    let mut protocol_config_data = protocol_config.try_borrow_mut_data()?;
+    updated.to_bytes_with_discriminator(protocol_config_data.as_mut())?;
+
+    Ok(())
+}

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -25,5 +25,8 @@ pub fn process_instruction(
         DlpV2Instruction::UpdateVerifierRegistry => {
             process_update_verifier_registry(accounts, data)
         }
+        DlpV2Instruction::UpdateProtocolConfig => {
+            process_update_protocol_config(program_id, accounts, data)
+        }
     }
 }

--- a/src/v2/processor/mod.rs
+++ b/src/v2/processor/mod.rs
@@ -26,7 +26,7 @@ pub fn process_instruction(
             process_update_verifier_registry(accounts, data)
         }
         DlpV2Instruction::UpdateProtocolConfig => {
-            process_update_protocol_config(program_id, accounts, data)
+            process_update_protocol_config(accounts, data)
         }
     }
 }

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -32,8 +32,8 @@ async fn test_v2_update_protocol_config() {
     update_args.operator_response_timeout_slots = 23;
     update_args.challenger_reveal_timeout_slots = 29;
     update_args.payout_timelock_slots = 31;
-    update_args.verifiers_per_commitment = 5;
-    update_args.approval_threshold = 3;
+    update_args.verifiers_per_commitment = 1;
+    update_args.approval_threshold = 1;
     update_args.max_window_extensions = 2;
     update_args.match_penalty_bps = 700;
 

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -2,7 +2,7 @@ use dlp_api::{
     pda::fees_vault_pda,
     v2::{
         instruction_builder::update_protocol_config, pda::protocol_config_pda,
-        ProtocolConfig,
+        DlpV2Instruction, ProtocolConfig, UpdateProtocolConfigArgs,
     },
 };
 use solana_sdk::{
@@ -10,11 +10,28 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use wheels::layout::Decodable;
+use wheels::layout::{Decodable, Encodable};
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[test]
+fn test_v2_update_protocol_config_instruction_data_uses_one_byte_tag() {
+    let args = valid_args();
+    let ix = update_protocol_config(Pubkey::new_unique(), args.clone());
+    let encoded_args = args.encode().unwrap();
+
+    assert_eq!(ix.data[0], DlpV2Instruction::UpdateProtocolConfig as u8);
+    assert_eq!(ix.data.len(), 1 + encoded_args.len());
+    assert_eq!(&ix.data[1..], encoded_args.as_slice());
+
+    let decoded =
+        <UpdateProtocolConfigArgs as Decodable>::decode(&ix.data[1..]).unwrap();
+    assert_eq!(*decoded.resolver(), args.resolver);
+    assert_eq!(decoded.min_verifier_bond(), args.min_verifier_bond);
+    assert_eq!(decoded.approval_threshold(), args.approval_threshold);
+}
 
 #[tokio::test]
 async fn test_v2_update_protocol_config() {

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -1,0 +1,171 @@
+use dlp_api::{
+    pda::fees_vault_pda,
+    v2::{
+        instruction_builder::update_protocol_config, pda::protocol_config_pda,
+        ProtocolConfig,
+    },
+};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod fixtures;
+
+use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+
+#[tokio::test]
+async fn test_v2_update_protocol_config() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+    let initial_args = valid_args();
+
+    init_v2(&banks, &payer, &authority, blockhash, initial_args).await;
+
+    let mut update_args = valid_args();
+    update_args.vrf_program = Pubkey::new_unique();
+    update_args.vrf_config = Pubkey::new_unique();
+    update_args.resolver = Pubkey::new_unique();
+    update_args.min_operator_bond = 11;
+    update_args.min_verifier_bond = 13;
+    update_args.min_challenger_stake = 17;
+    update_args.challenge_window_slots = 19;
+    update_args.operator_response_timeout_slots = 23;
+    update_args.challenger_reveal_timeout_slots = 29;
+    update_args.payout_timelock_slots = 31;
+    update_args.selected_verifier_count = 5;
+    update_args.approval_threshold = 3;
+    update_args.max_window_extensions = 2;
+    update_args.match_penalty_bps = 700;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = update_protocol_config(authority.pubkey(), update_args.clone());
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_ok());
+
+    let protocol_config_account = banks
+        .get_account(protocol_config_pda())
+        .await
+        .unwrap()
+        .unwrap();
+    let protocol_config = ProtocolConfig::try_from_bytes_with_discriminator(
+        &protocol_config_account.data,
+    )
+    .unwrap();
+
+    assert_eq!(protocol_config.authority, authority.pubkey());
+    assert!(!protocol_config.paused);
+    assert_eq!(protocol_config.vrf_program, update_args.vrf_program);
+    assert_eq!(protocol_config.vrf_config, update_args.vrf_config);
+    assert_eq!(protocol_config.resolver, update_args.resolver);
+    assert_eq!(protocol_config.protocol_fee_vault, fees_vault_pda());
+    assert_eq!(
+        protocol_config.min_operator_bond,
+        update_args.min_operator_bond
+    );
+    assert_eq!(
+        protocol_config.min_verifier_bond,
+        update_args.min_verifier_bond
+    );
+    assert_eq!(
+        protocol_config.min_challenger_stake,
+        update_args.min_challenger_stake
+    );
+    assert_eq!(
+        protocol_config.challenge_window_slots,
+        update_args.challenge_window_slots
+    );
+    assert_eq!(
+        protocol_config.operator_response_timeout_slots,
+        update_args.operator_response_timeout_slots
+    );
+    assert_eq!(
+        protocol_config.challenger_reveal_timeout_slots,
+        update_args.challenger_reveal_timeout_slots
+    );
+    assert_eq!(
+        protocol_config.payout_timelock_slots,
+        update_args.payout_timelock_slots
+    );
+    assert_eq!(
+        protocol_config.selected_verifier_count,
+        update_args.selected_verifier_count
+    );
+    assert_eq!(
+        protocol_config.approval_threshold,
+        update_args.approval_threshold
+    );
+    assert_eq!(
+        protocol_config.max_window_extensions,
+        update_args.max_window_extensions
+    );
+    assert_eq!(
+        protocol_config.match_penalty_bps,
+        update_args.match_penalty_bps
+    );
+}
+
+#[tokio::test]
+async fn test_v2_update_protocol_config_fails_with_wrong_authority() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+
+    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+
+    let wrong_authority = Keypair::new();
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = update_protocol_config(wrong_authority.pubkey(), valid_args());
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &wrong_authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_update_protocol_config_fails_with_invalid_args() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+
+    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+
+    let mut args = valid_args();
+    args.approval_threshold = args.selected_verifier_count + 1;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let ix = update_protocol_config(authority.pubkey(), args);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn test_v2_update_protocol_config_fails_with_wrong_protocol_config_pda() {
+    let (banks, payer, authority, blockhash) = setup_program_test_env().await;
+
+    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+
+    let blockhash = banks.get_latest_blockhash().await.unwrap();
+    let mut ix = update_protocol_config(authority.pubkey(), valid_args());
+    ix.accounts[1].pubkey = Pubkey::new_unique();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[&payer, &authority],
+        blockhash,
+    );
+
+    assert!(banks.process_transaction(tx).await.is_err());
+}

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
+use wheels::layout::Decodable;
 
 mod fixtures;
 
@@ -23,8 +24,6 @@ async fn test_v2_update_protocol_config() {
     init_v2(&banks, &payer, &authority, blockhash, initial_args).await;
 
     let mut update_args = valid_args();
-    update_args.vrf_program = Pubkey::new_unique();
-    update_args.vrf_config = Pubkey::new_unique();
     update_args.resolver = Pubkey::new_unique();
     update_args.min_operator_bond = 11;
     update_args.min_verifier_bond = 13;
@@ -33,7 +32,7 @@ async fn test_v2_update_protocol_config() {
     update_args.operator_response_timeout_slots = 23;
     update_args.challenger_reveal_timeout_slots = 29;
     update_args.payout_timelock_slots = 31;
-    update_args.selected_verifier_count = 5;
+    update_args.verifiers_per_commitment = 5;
     update_args.approval_threshold = 3;
     update_args.max_window_extensions = 2;
     update_args.match_penalty_bps = 700;
@@ -54,59 +53,60 @@ async fn test_v2_update_protocol_config() {
         .await
         .unwrap()
         .unwrap();
-    let protocol_config = ProtocolConfig::try_from_bytes_with_discriminator(
-        &protocol_config_account.data,
-    )
-    .unwrap();
+    let protocol_config =
+        <ProtocolConfig as Decodable>::decode(&protocol_config_account.data)
+            .unwrap();
 
-    assert_eq!(protocol_config.authority, authority.pubkey());
-    assert!(!protocol_config.paused);
-    assert_eq!(protocol_config.vrf_program, update_args.vrf_program);
-    assert_eq!(protocol_config.vrf_config, update_args.vrf_config);
-    assert_eq!(protocol_config.resolver, update_args.resolver);
-    assert_eq!(protocol_config.protocol_fee_vault, fees_vault_pda());
     assert_eq!(
-        protocol_config.min_operator_bond,
+        protocol_config.discriminator(),
+        ProtocolConfig::DISCRIMINATOR
+    );
+    assert_eq!(*protocol_config.authority(), authority.pubkey());
+    assert!(!protocol_config.paused());
+    assert_eq!(*protocol_config.resolver(), update_args.resolver);
+    assert_eq!(*protocol_config.protocol_fee_vault(), fees_vault_pda());
+    assert_eq!(
+        protocol_config.min_operator_bond(),
         update_args.min_operator_bond
     );
     assert_eq!(
-        protocol_config.min_verifier_bond,
+        protocol_config.min_verifier_bond(),
         update_args.min_verifier_bond
     );
     assert_eq!(
-        protocol_config.min_challenger_stake,
+        protocol_config.min_challenger_stake(),
         update_args.min_challenger_stake
     );
     assert_eq!(
-        protocol_config.challenge_window_slots,
+        protocol_config.challenge_window_slots(),
         update_args.challenge_window_slots
     );
     assert_eq!(
-        protocol_config.operator_response_timeout_slots,
+        protocol_config.operator_response_timeout_slots(),
         update_args.operator_response_timeout_slots
     );
     assert_eq!(
-        protocol_config.challenger_reveal_timeout_slots,
+        protocol_config.challenger_reveal_timeout_slots(),
         update_args.challenger_reveal_timeout_slots
     );
     assert_eq!(
-        protocol_config.payout_timelock_slots,
+        protocol_config.payout_timelock_slots(),
         update_args.payout_timelock_slots
     );
     assert_eq!(
-        protocol_config.selected_verifier_count,
-        update_args.selected_verifier_count
+        protocol_config.verifiers_per_commitment(),
+        update_args.verifiers_per_commitment
     );
     assert_eq!(
-        protocol_config.approval_threshold,
+        protocol_config.approval_threshold(),
         update_args.approval_threshold
     );
     assert_eq!(
-        protocol_config.max_window_extensions,
+        protocol_config.max_window_extensions(),
         update_args.max_window_extensions
     );
     assert_eq!(
-        protocol_config.match_penalty_bps,
+        protocol_config.match_penalty_bps(),
         update_args.match_penalty_bps
     );
 }
@@ -137,7 +137,7 @@ async fn test_v2_update_protocol_config_fails_with_invalid_args() {
     init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
 
     let mut args = valid_args();
-    args.approval_threshold = args.selected_verifier_count + 1;
+    args.approval_threshold = args.verifiers_per_commitment + 1;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = update_protocol_config(authority.pubkey(), args);

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -14,16 +14,26 @@ use wheels::layout::Decodable;
 
 mod fixtures;
 
-use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
+use crate::fixtures::v2::{
+    initialize_protocol_config, setup_program_test_env,
+    valid_protocol_config_args,
+};
 
 #[tokio::test]
-async fn test_v2_update_protocol_config() {
+async fn test_update_protocol_config() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
-    let initial_args = valid_args();
+    let initial_args = valid_protocol_config_args();
 
-    init_v2(&banks, &payer, &authority, blockhash, initial_args).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        initial_args,
+    )
+    .await;
 
-    let mut update_args = valid_args();
+    let mut update_args = valid_protocol_config_args();
     update_args.resolver = Pubkey::new_unique();
     update_args.min_operator_bond = 11;
     update_args.min_verifier_bond = 13;
@@ -112,14 +122,24 @@ async fn test_v2_update_protocol_config() {
 }
 
 #[tokio::test]
-async fn test_v2_update_protocol_config_fails_with_wrong_authority() {
+async fn test_update_protocol_config_fails_with_wrong_authority() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        valid_protocol_config_args(),
+    )
+    .await;
 
     let wrong_authority = Keypair::new();
     let blockhash = banks.get_latest_blockhash().await.unwrap();
-    let ix = update_protocol_config(wrong_authority.pubkey(), valid_args());
+    let ix = update_protocol_config(
+        wrong_authority.pubkey(),
+        valid_protocol_config_args(),
+    );
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&payer.pubkey()),
@@ -131,12 +151,19 @@ async fn test_v2_update_protocol_config_fails_with_wrong_authority() {
 }
 
 #[tokio::test]
-async fn test_v2_update_protocol_config_fails_with_invalid_args() {
+async fn test_update_protocol_config_fails_with_invalid_args() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        valid_protocol_config_args(),
+    )
+    .await;
 
-    let mut args = valid_args();
+    let mut args = valid_protocol_config_args();
     args.approval_threshold = args.verifiers_per_commitment + 1;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
@@ -152,13 +179,23 @@ async fn test_v2_update_protocol_config_fails_with_invalid_args() {
 }
 
 #[tokio::test]
-async fn test_v2_update_protocol_config_fails_with_wrong_protocol_config_pda() {
+async fn test_update_protocol_config_fails_with_wrong_protocol_config_pda() {
     let (banks, payer, authority, blockhash) = setup_program_test_env().await;
 
-    init_v2(&banks, &payer, &authority, blockhash, valid_args()).await;
+    initialize_protocol_config(
+        &banks,
+        &payer,
+        &authority,
+        blockhash,
+        valid_protocol_config_args(),
+    )
+    .await;
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
-    let mut ix = update_protocol_config(authority.pubkey(), valid_args());
+    let mut ix = update_protocol_config(
+        authority.pubkey(),
+        valid_protocol_config_args(),
+    );
     ix.accounts[1].pubkey = Pubkey::new_unique();
     let tx = Transaction::new_signed_with_payer(
         &[ix],

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -2,7 +2,7 @@ use dlp_api::{
     pda::fees_vault_pda,
     v2::{
         instruction_builder::update_protocol_config, pda::protocol_config_pda,
-        DlpV2Instruction, ProtocolConfig, UpdateProtocolConfigArgs,
+        ProtocolConfig,
     },
 };
 use solana_sdk::{
@@ -10,28 +10,11 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use wheels::layout::{Decodable, Encodable};
+use wheels::layout::Decodable;
 
 mod fixtures;
 
 use crate::fixtures::v2::{init_v2, setup_program_test_env, valid_args};
-
-#[test]
-fn test_v2_update_protocol_config_instruction_data_uses_one_byte_tag() {
-    let args = valid_args();
-    let ix = update_protocol_config(Pubkey::new_unique(), args.clone());
-    let encoded_args = args.encode().unwrap();
-
-    assert_eq!(ix.data[0], DlpV2Instruction::UpdateProtocolConfig as u8);
-    assert_eq!(ix.data.len(), 1 + encoded_args.len());
-    assert_eq!(&ix.data[1..], encoded_args.as_slice());
-
-    let decoded =
-        <UpdateProtocolConfigArgs as Decodable>::decode(&ix.data[1..]).unwrap();
-    assert_eq!(*decoded.resolver(), args.resolver);
-    assert_eq!(decoded.min_verifier_bond(), args.min_verifier_bond);
-    assert_eq!(decoded.approval_threshold(), args.approval_threshold);
-}
 
 #[tokio::test]
 async fn test_v2_update_protocol_config() {

--- a/tests/test_v2_update_protocol_config.rs
+++ b/tests/test_v2_update_protocol_config.rs
@@ -1,8 +1,9 @@
 use dlp_api::{
     pda::fees_vault_pda,
     v2::{
-        instruction_builder::update_protocol_config, pda::protocol_config_pda,
-        ProtocolConfig,
+        instruction_builder::update_protocol_config,
+        pda::{protocol_config_pda, PROTOCOL_CONFIG_SEED},
+        ProtocolConfig, UpdateProtocolConfigArgs,
     },
 };
 use solana_sdk::{
@@ -29,23 +30,28 @@ async fn test_update_protocol_config() {
         &payer,
         &authority,
         blockhash,
-        initial_args,
+        initial_args.clone(),
     )
     .await;
 
-    let mut update_args = valid_protocol_config_args();
-    update_args.resolver = Pubkey::new_unique();
-    update_args.min_operator_bond = 11;
-    update_args.min_verifier_bond = 13;
-    update_args.min_challenger_stake = 17;
-    update_args.challenge_window_slots = 19;
-    update_args.operator_response_timeout_slots = 23;
-    update_args.challenger_reveal_timeout_slots = 29;
-    update_args.payout_timelock_slots = 31;
-    update_args.verifiers_per_commitment = 1;
-    update_args.approval_threshold = 1;
-    update_args.max_window_extensions = 2;
-    update_args.match_penalty_bps = 700;
+    let update_args = UpdateProtocolConfigArgs {
+        resolver: Pubkey::new_unique(),
+        min_operator_bond: initial_args.min_operator_bond + 10,
+        min_verifier_bond: initial_args.min_verifier_bond + 12,
+        min_challenger_stake: initial_args.min_challenger_stake + 16,
+        challenge_window_slots: initial_args.challenge_window_slots + 9,
+        operator_response_timeout_slots: initial_args
+            .operator_response_timeout_slots
+            + 13,
+        challenger_reveal_timeout_slots: initial_args
+            .challenger_reveal_timeout_slots
+            + 19,
+        payout_timelock_slots: initial_args.payout_timelock_slots + 21,
+        verifiers_per_commitment: initial_args.verifiers_per_commitment,
+        approval_threshold: initial_args.approval_threshold,
+        max_window_extensions: initial_args.max_window_extensions + 1,
+        match_penalty_bps: initial_args.match_penalty_bps + 200,
+    };
 
     let blockhash = banks.get_latest_blockhash().await.unwrap();
     let ix = update_protocol_config(authority.pubkey(), update_args.clone());
@@ -64,13 +70,15 @@ async fn test_update_protocol_config() {
         .unwrap()
         .unwrap();
     let protocol_config =
-        <ProtocolConfig as Decodable>::decode(&protocol_config_account.data)
-            .unwrap();
+        ProtocolConfig::decode(&protocol_config_account.data).unwrap();
+    let (_, expected_protocol_config_bump) =
+        Pubkey::find_program_address(&[PROTOCOL_CONFIG_SEED], &dlp_api::id());
 
     assert_eq!(
         protocol_config.discriminator(),
         ProtocolConfig::DISCRIMINATOR
     );
+    assert_eq!(protocol_config.bump(), expected_protocol_config_bump);
     assert_eq!(*protocol_config.authority(), authority.pubkey());
     assert!(!protocol_config.paused());
     assert_eq!(*protocol_config.resolver(), update_args.resolver);


### PR DESCRIPTION
Implements the DLP v2 bootstrap instruction `UpdateProtocolConfig`, which lets the protocol authority update config values used by future v2 commitments.

Closes #206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating global protocol configuration.
  * Configuration updates can modify resolver, bond, stake, timeout, timelock, verifier, approval, extension, and penalty settings.
  * Updates preserve existing authority, pause status, and fee vault details.

* **Bug Fixes**
  * Added validation for authorization, account correctness, and invalid configuration combinations.

* **Tests**
  * Added coverage for successful updates, data round-tripping, and expected failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->