### PR TITLE
docs: fix protocol claim fees account list

### DIFF
--- a/src/processor/protocol_claim_fees.rs
+++ b/src/processor/protocol_claim_fees.rs
@@ -14,8 +14,9 @@ use crate::{
 ///
 /// Accounts:
 ///
-/// 1. `[signer]`   admin account that can claim the fees
-/// 2. `[writable]` protocol fees vault PDA
+/// 0: `[signer]`   admin account that can claim the fees
+/// 1: `[writable]` protocol fees vault PDA
+/// 2: `[]`         delegation program data account
 ///
 /// Requirements:
 ///


### PR DESCRIPTION
## Problem

The `process_protocol_claim_fees` documentation was missing the `delegation_program_data` account required by the implementation.


## Solution

Updated the account documentation to include all three required accounts with their correct indices and order.

The `delegation_program_data` account is required by the code to load the protocol program upgrade authority.


## Before & After Screenshots

Documentation-only change.


## Deploy Notes

No deployment changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated account documentation for fee claiming to include the required delegation program data account.
  * Clarified the order and indexing of accounts used during fee-claim processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->