### PR TITLE
ci: use shared Magic Lab project automation

### DIFF
--- a/.github/workflows/auto_add_to_board.yml
+++ b/.github/workflows/auto_add_to_board.yml
@@ -1,0 +1,19 @@
+name: Magic Lab Project Automation
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled, unlabeled]
+  pull_request:
+    types: [opened, reopened, labeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  magic-lab:
+    name: Update Magic Lab
+    uses: magicblock-labs/.github/.github/workflows/magic_lab_automation.yml@21cae0c2ecb071828423f673076e887f8a5fe63d
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
| Status | Type | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | N/A |

## Problem

Magic Lab issue and pull-request automation is currently managed by a repository-specific project workflow.

## Solution

Add the shared Magic Lab project automation caller. It adds issues and pull requests to the project, assigns unassigned items to their authors, synchronizes P0-P3 priority labels, and closes linked issues after merge.

The shared workflow is pinned to an immutable commit SHA. The repository must be granted access to the ADD_TO_PROJECT_PAT organization secret and its fine-grained token.

## Before & After Screenshots

Not applicable.

## Other changes (e.g. bug fixes, small refactors)

None.

## Deploy Notes

Disable the corresponding native Magic Lab project workflow after this PR is ready.

**New scripts**:

- None

**New dependencies**:

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated project-board management for newly opened, reopened, transferred, labeled, or closed issues and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->